### PR TITLE
APP-1690 HelpDesk Bot doesn't accept connection requests from external users

### DIFF
--- a/helpdesk-bot/src/main/java/org/symphonyoss/symphony/bots/helpdesk/bot/bootstrap/HelpDeskBootstrap.java
+++ b/helpdesk-bot/src/main/java/org/symphonyoss/symphony/bots/helpdesk/bot/bootstrap/HelpDeskBootstrap.java
@@ -97,7 +97,8 @@ public class HelpDeskBootstrap implements ApplicationListener<ApplicationReadyEv
   }
 
   /**
-   * Authenticates bot user, starts symphony client, and register listeners
+   * Authenticates bot user, starts symphony client, register listeners and accept incoming requests
+   * from external users.
    * @param applicationContext Spring application context
    */
   private HelpDeskSymphonyClient initSymphonyClient(ApplicationContext applicationContext, SymAuth symAuth) {
@@ -108,6 +109,8 @@ public class HelpDeskBootstrap implements ApplicationListener<ApplicationReadyEv
       symphonyClient.init(symAuth, config.getEmail(), config.getAgentUrl(), config.getPodUrl());
 
       registerListeners(symphonyClient, applicationContext);
+
+      acceptIncomingRequests(applicationContext);
 
       return symphonyClient;
     } catch (HelpDeskAuthenticationException | InitException e) {
@@ -128,6 +131,15 @@ public class HelpDeskBootstrap implements ApplicationListener<ApplicationReadyEv
     symphonyClient.getMessageService().addRoomServiceEventListener(roomEventListener);
     symphonyClient.getMessageService().addConnectionsEventListener(connectionListener);
     symphonyClient.getMessageService().addMessageListener(chatListener);
+  }
+
+  /**
+   * Accept incoming requests from the external users
+   * @param applicationContext Spring application context
+   */
+  private void acceptIncomingRequests(ApplicationContext applicationContext) {
+    AutoConnectionAcceptListener connectionListener = applicationContext.getBean(AutoConnectionAcceptListener.class);
+    connectionListener.acceptAllIncomingRequests();
   }
 
   /**

--- a/helpdesk-bot/src/main/java/org/symphonyoss/symphony/bots/helpdesk/bot/listener/AutoConnectionAcceptListener.java
+++ b/helpdesk-bot/src/main/java/org/symphonyoss/symphony/bots/helpdesk/bot/listener/AutoConnectionAcceptListener.java
@@ -12,8 +12,15 @@ import org.symphonyoss.symphony.clients.ConnectionsClient;
 import org.symphonyoss.symphony.clients.model.SymUserConnection;
 
 import java.util.List;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+import javax.annotation.PostConstruct;
 
 /**
+ * Listener to accept incoming requests from external users.
+ *
  * Created by nick.tarsillo on 11/24/17.
  */
 @Service
@@ -21,27 +28,39 @@ public class AutoConnectionAcceptListener implements ConnectionsEventListener {
 
   private static final Logger LOG = LoggerFactory.getLogger(AutoConnectionAcceptListener.class);
 
+  private static final Integer DELAY_RETRIES = 5;
+
   private final SymphonyClient symphonyClient;
+
+  private ScheduledExecutorService executorService;
 
   public AutoConnectionAcceptListener(SymphonyClient symphonyClient) {
     this.symphonyClient = symphonyClient;
+    this.executorService = Executors.newSingleThreadScheduledExecutor();
   }
 
   @Override
   public void onSymConnectionRequested(SymConnectionRequested symConnectionRequested) {
+    acceptAllIncomingRequests();
+  }
+
+  /**
+   * Accept incoming requests from external users.
+   */
+  public void acceptAllIncomingRequests() {
     ConnectionsClient connectionsClient = symphonyClient.getConnectionsClient();
+
     try {
       List<SymUserConnection> connectionList = connectionsClient.getIncomingRequests();
       for (SymUserConnection userConnection : connectionList) {
         connectionsClient.acceptConnectionRequest(userConnection);
       }
     } catch (ConnectionsException e) {
-      LOG.error("Get pending requests failed: ", e);
+      LOG.error("Accept pending requests failed: ", e);
+      executorService.schedule(() -> acceptAllIncomingRequests(), DELAY_RETRIES, TimeUnit.SECONDS);
     }
   }
 
   @Override
-  public void onSymConnectionAccepted(SymConnectionAccepted symConnectionAccepted) {
-
-  }
+  public void onSymConnectionAccepted(SymConnectionAccepted symConnectionAccepted) {}
 }


### PR DESCRIPTION
- On bootstrap, helpdesk bot must verify new connection requests that has been sent while the application was out of service