### PR TITLE
APP-1696 Added support for special text rendering in ticket creation cards

### DIFF
--- a/helpdesk-ai/src/main/java/org/symphonyoss/symphony/bots/ai/message/MessageProducer.java
+++ b/helpdesk-ai/src/main/java/org/symphonyoss/symphony/bots/ai/message/MessageProducer.java
@@ -1,8 +1,5 @@
 package org.symphonyoss.symphony.bots.ai.message;
 
-import org.jsoup.Jsoup;
-import org.jsoup.nodes.Document;
-import org.jsoup.nodes.Element;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.symphonyoss.client.SymphonyClient;
@@ -21,7 +18,6 @@ import org.symphonyoss.symphony.clients.model.SymStream;
 import org.symphonyoss.symphony.clients.model.SymUser;
 
 import java.io.File;
-import java.util.List;
 
 /**
  * Created by rsanchez on 30/11/17.
@@ -146,7 +142,7 @@ public class MessageProducer {
   private SymMessage buildChimeMessage(SymphonyAiMessage symphonyAiMessage) {
     StringBuilder message = new StringBuilder("<messageML>");
     SymMessage symMessage = new SymMessage();
-    message.append(parseMessage(symphonyAiMessage));
+    message.append(SymMessageUtil.parseMessage(symphonyAiMessage.toSymMessage()));
     message.append("</messageML>");
 
     symMessage.setMessage(message.toString());
@@ -198,7 +194,7 @@ public class MessageProducer {
 
     message.append(header);
     if (symphonyAiMessage.getMessageData() != null) {
-      message.append(parseMessage(symphonyAiMessage));
+      message.append(SymMessageUtil.parseMessage(symphonyAiMessage.toSymMessage()));
     } else {
       message.append(symphonyAiMessage.getAiMessage());
     }
@@ -226,36 +222,6 @@ public class MessageProducer {
     attachmentMessage.setStreamId(symphonyAiMessage.getStreamId());
 
     return symphonyClientUtil.getFileAttachment(attachmentInfo, attachmentMessage);
-  }
-  
-  /**
-   * Parse a message into valid MessageML format
-   * @param message SymphonyAiMessage with the message contents
-   * @return StringBuilder with the output message in MessageML format
-   */
-  private String parseMessage(SymphonyAiMessage message) {
-    Element elementMessageML;
-    StringBuilder textDoc = new StringBuilder("");
-
-    Document doc = Jsoup.parse(message.getMessageData());
-
-    doc.select("errors").remove();
-    elementMessageML = doc.select("messageML").first();
-    if (elementMessageML == null) {
-      elementMessageML = doc.select("div").first();
-    }
-
-    if (elementMessageML != null) {
-      elementMessageML.childNodes().forEach(node -> {
-        if (node.toString().equalsIgnoreCase("<br>")) {
-          textDoc.append("<br/>");
-        } else {
-          textDoc.append(node.toString());
-        }
-      });
-    }
-
-    return textDoc.toString();
   }
 
   /**

--- a/helpdesk-message-proxy-service/src/main/java/org/symphonyoss/symphony/bots/helpdesk/messageproxy/service/TicketService.java
+++ b/helpdesk-message-proxy-service/src/main/java/org/symphonyoss/symphony/bots/helpdesk/messageproxy/service/TicketService.java
@@ -24,19 +24,14 @@ import org.symphonyoss.symphony.bots.helpdesk.service.model.Ticket;
 import org.symphonyoss.symphony.bots.helpdesk.service.model.UserInfo;
 import org.symphonyoss.symphony.bots.helpdesk.service.ticket.client.TicketClient;
 import org.symphonyoss.symphony.bots.utility.message.SymMessageUtil;
-import org.symphonyoss.symphony.clients.model.SymAttachmentInfo;
 import org.symphonyoss.symphony.clients.model.SymMessage;
 import org.symphonyoss.symphony.clients.model.SymStream;
 import org.symphonyoss.symphony.clients.model.SymUser;
 
-import java.io.BufferedReader;
 import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
-import java.util.List;
 
 
 /**

--- a/helpdesk-message-proxy-service/src/main/java/org/symphonyoss/symphony/bots/helpdesk/messageproxy/service/TicketService.java
+++ b/helpdesk-message-proxy-service/src/main/java/org/symphonyoss/symphony/bots/helpdesk/messageproxy/service/TicketService.java
@@ -168,7 +168,11 @@ public class TicketService {
       return username + " sent a table!";
     }
 
-    return message.getMessageText();
+    if (message.getMessage() != null && message.getEntityData().equals("{}")) {
+      return SymMessageUtil.parseMessage(message);
+    } else {
+      return message.getMessageText();
+    }
   }
 
   public void sendClientMessageToServiceStreamId(String streamId, SymMessage message) {

--- a/helpdesk-message-proxy-service/src/test/java/org/symphonyoss/symphony/bots/helpdesk/messageproxy/service/TicketServiceTest.java
+++ b/helpdesk-message-proxy-service/src/test/java/org/symphonyoss/symphony/bots/helpdesk/messageproxy/service/TicketServiceTest.java
@@ -63,6 +63,26 @@ public class TicketServiceTest {
   private static final String TABLE_MESSAGE = "<div data-format=\"PresentationML\"data-version"
       + "=\"2.0\"><table><tr><td>text</td></tr></table></div>";
 
+  private static final String COMPLEX_MESSAGE =
+      "<div data-format=\"PresentationML\" data-version=\"2.0\"><span class=\"entity\" "
+          + "data-entity-id=\"keyword1\">#hash</span> <span class=\"entity\" "
+          + "data-entity-id=\"keyword2\">$cash</span> <span class=\"entity\" "
+          + "data-entity-id=\"mention3\">@HelpDesk</span> mention <b>bold</b> <i>italic</i> "
+          + "<b><i>combo</i></b><ul><li>bullet1</li><li>bullet2</li></ul></div>";
+
+  private static final String COMPLEX_MESSAGE_ENTITY_DATA =
+      "{\"keyword1\":{\"type\":\"org.symphonyoss.taxonomy\",\"version\":\"1.0\","
+          + "\"id\":[{\"type\":\"org.symphonyoss.taxonomy.hashtag\",\"value\":\"hash\"}]},"
+          + "\"keyword2\":{\"type\":\"org.symphonyoss.fin.security\",\"version\":\"1.0\","
+          + "\"id\":[{\"type\":\"org.symphonyoss.fin.security.id.ticker\",\"value\":\"cash\"}]},"
+          + "\"mention3\":{\"type\":\"com.symphony.user.mention\",\"version\":\"1.0\","
+          + "\"id\":[{\"type\":\"com.symphony.user.userId\",\"value\":\"9208409883842\"}]}}";
+
+  private static final String EXPECTED_COMPLEX_MESSAGE =
+      "<hash tag=\\\"hash\\\" /> <cash tag=\\\"cash\\\" /> <mention uid=\\\"9208409883842\\\" /> mention "
+          + "<b>bold</b> <i>italic</i> <b><i>combo</i></b><ul>\\n <li>bullet1</li>\\n "
+          + "<li>bullet2</li>\\n</ul>";
+
   private static final Long TEST_TIMESTAMP = 1L;
 
   private static final Long TEST_FROM_USER_ID = 2L;
@@ -82,7 +102,7 @@ public class TicketServiceTest {
   private SymphonyClient symphonyClient;
 
   @Before
-  public void initMocks(){
+  public void initMocks() {
     MockitoAnnotations.initMocks(this);
 
     when(symphonyClient.getUsersClient()).thenReturn(usersClient);
@@ -164,7 +184,8 @@ public class TicketServiceTest {
     stream.setStreamId(TEST_CLIENT_STREAM_ID);
     when(messagesClient.sendMessage(stream, symMessage)).thenReturn(symMessage);
     stream.setStreamId(TEST_AGENT_STREAM);
-    when(messagesClient.sendMessage(stream, getTestClaimMessage())).thenReturn(getTestClaimMessage());
+    when(messagesClient.sendMessage(stream, getTestClaimMessage())).thenReturn(
+        getTestClaimMessage());
     stream.setStreamId(TEST_SERVICE_STREAM_ID);
     when(messagesClient.sendMessage(stream, getTestInstructionalMessage()))
         .thenReturn(getTestInstructionalMessage());
@@ -174,6 +195,23 @@ public class TicketServiceTest {
     Ticket ticket = ticketService.createTicket(TEST_TICKET_ID, testSym, serviceStream);
 
     assertEquals("Ticket return", mockTicket, ticket);
+  }
+
+  @Test
+  public void testSendComplexTicketMessage() throws UsersClientException, MessagesException {
+    getTestUser();
+
+    SymMessage testSym = getTestSymMessage();
+    testSym.setMessage(COMPLEX_MESSAGE);
+    testSym.setEntityData(COMPLEX_MESSAGE_ENTITY_DATA);
+
+    ticketService.sendTicketMessageToAgentStreamId(mock(Ticket.class), testSym);
+
+    ArgumentCaptor<SymMessage> captor = ArgumentCaptor.forClass(SymMessage.class);
+    verify(messagesClient).sendMessage(any(SymStream.class), captor.capture());
+    SymMessage sentMessage = captor.getValue();
+
+    assertTrue(sentMessage.getEntityData().contains("\"question\":\"" + EXPECTED_COMPLEX_MESSAGE));
   }
 
   @Test
@@ -189,7 +227,8 @@ public class TicketServiceTest {
     verify(messagesClient).sendMessage(any(SymStream.class), captor.capture());
     SymMessage sentMessage = captor.getValue();
 
-    assertTrue(sentMessage.getEntityData().contains("\"question\":\"" + user.getDisplayName() + " sent a chime!\""));
+    assertTrue(sentMessage.getEntityData()
+        .contains("\"question\":\"" + user.getDisplayName() + " sent a chime!\""));
   }
 
   @Test
@@ -210,11 +249,13 @@ public class TicketServiceTest {
     verify(messagesClient).sendMessage(any(SymStream.class), captor.capture());
     SymMessage sentMessage = captor.getValue();
 
-    assertTrue(sentMessage.getEntityData().contains("\"question\":\"" + user.getDisplayName() + " sent an attachment!\""));
+    assertTrue(sentMessage.getEntityData()
+        .contains("\"question\":\"" + user.getDisplayName() + " sent an attachment!\""));
   }
 
   @Test
-  public void testSendTicketMessageWithAttachmentAndText() throws UsersClientException, MessagesException {
+  public void testSendTicketMessageWithAttachmentAndText()
+      throws UsersClientException, MessagesException {
     getTestUser();
     List<SymAttachmentInfo> attachments = new ArrayList<>();
     attachments.add(new SymAttachmentInfo());
@@ -248,7 +289,8 @@ public class TicketServiceTest {
     verify(messagesClient).sendMessage(any(SymStream.class), captor.capture());
     SymMessage sentMessage = captor.getValue();
 
-    assertTrue(sentMessage.getEntityData().contains("\"question\":\"" + user.getDisplayName() + " sent a table!\""));
+    assertTrue(sentMessage.getEntityData()
+        .contains("\"question\":\"" + user.getDisplayName() + " sent a table!\""));
   }
 
   @Test

--- a/helpdesk-message-proxy-service/src/test/java/org/symphonyoss/symphony/bots/helpdesk/messageproxy/service/TicketServiceTest.java
+++ b/helpdesk-message-proxy-service/src/test/java/org/symphonyoss/symphony/bots/helpdesk/messageproxy/service/TicketServiceTest.java
@@ -214,7 +214,7 @@ public class TicketServiceTest {
   }
 
   @Test
-  public void testSendTicketMessageWithText() throws UsersClientException, MessagesException {
+  public void testSendTicketMessageWithAttachmentAndText() throws UsersClientException, MessagesException {
     getTestUser();
     List<SymAttachmentInfo> attachments = new ArrayList<>();
     attachments.add(new SymAttachmentInfo());
@@ -222,6 +222,7 @@ public class TicketServiceTest {
 
     SymMessage testSym = getTestSymMessage();
     testSym.setMessageText(ATTACHMENT_MESSAGE);
+    testSym.setEntityData("{}");
     testSym.setAttachments(attachments);
 
     ticketService.sendTicketMessageToAgentStreamId(mock(Ticket.class), testSym);
@@ -230,7 +231,7 @@ public class TicketServiceTest {
     verify(messagesClient).sendMessage(any(SymStream.class), captor.capture());
     SymMessage sentMessage = captor.getValue();
 
-    assertTrue(sentMessage.getEntityData().contains("\"question\":\"" + ATTACHMENT_MESSAGE));
+    assertTrue(sentMessage.getEntityData().contains("\"question\":\"\\n" + ATTACHMENT_MESSAGE));
   }
 
   @Test

--- a/symphony-utility/src/main/java/org/symphonyoss/symphony/bots/utility/message/SymMessageUtil.java
+++ b/symphony-utility/src/main/java/org/symphonyoss/symphony/bots/utility/message/SymMessageUtil.java
@@ -69,4 +69,34 @@ public class SymMessageUtil {
 
     return elementMessageML != null;
   }
+
+  /**
+   * Parse a message into valid MessageML format
+   * @param message SymphonyAiMessage with the message contents
+   * @return StringBuilder with the output message in MessageML format
+   */
+  public static String parseMessage(SymMessage message) {
+    Element elementMessageML;
+    StringBuilder textDoc = new StringBuilder("");
+
+    Document doc = Jsoup.parse(message.getMessage());
+
+    doc.select("errors").remove();
+    elementMessageML = doc.select("messageML").first();
+    if (elementMessageML == null) {
+      elementMessageML = doc.select("div").first();
+    }
+
+    if (elementMessageML != null) {
+      elementMessageML.childNodes().forEach(node -> {
+        if (node.toString().equalsIgnoreCase("<br>")) {
+          textDoc.append("<br/>");
+        } else {
+          textDoc.append(node.toString());
+        }
+      });
+    }
+
+    return textDoc.toString();
+  }
 }


### PR DESCRIPTION
This PR aims to add support for non plain text rendering in new Ticket cards in the queue room.
It adds support for 
- Styled texts: bullet lists, bold text, italic text and hyperlinks.
- Entities: cashtags, hashtags and mentions.

:warning: **Important**: This PR uses some generalized code from https://github.com/symphonyoss/GroupID/pull/52, so please check that one first before merging this branch.