### PR TITLE
APP-1696, APP-1696 Added support for formatted text in queue room new ticket messages and emoji shortcodes in all messages

### DIFF
--- a/helpdesk-ai/src/main/java/org/symphonyoss/symphony/bots/ai/message/MessageProducer.java
+++ b/helpdesk-ai/src/main/java/org/symphonyoss/symphony/bots/ai/message/MessageProducer.java
@@ -1,8 +1,5 @@
 package org.symphonyoss.symphony.bots.ai.message;
 
-import org.jsoup.Jsoup;
-import org.jsoup.nodes.Document;
-import org.jsoup.nodes.Element;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.symphonyoss.client.SymphonyClient;
@@ -21,7 +18,6 @@ import org.symphonyoss.symphony.clients.model.SymStream;
 import org.symphonyoss.symphony.clients.model.SymUser;
 
 import java.io.File;
-import java.util.List;
 
 /**
  * Created by rsanchez on 30/11/17.
@@ -146,7 +142,7 @@ public class MessageProducer {
   private SymMessage buildChimeMessage(SymphonyAiMessage symphonyAiMessage) {
     StringBuilder message = new StringBuilder("<messageML>");
     SymMessage symMessage = new SymMessage();
-    message.append(parseMessage(symphonyAiMessage));
+    message.append(SymMessageUtil.parseMessage(symphonyAiMessage.toSymMessage()));
     message.append("</messageML>");
 
     symMessage.setMessage(message.toString());
@@ -198,7 +194,7 @@ public class MessageProducer {
 
     message.append(header);
     if (symphonyAiMessage.getMessageData() != null) {
-      message.append(parseMessage(symphonyAiMessage));
+      message.append(SymMessageUtil.parseMessage(symphonyAiMessage.toSymMessage()));
     } else {
       message.append(symphonyAiMessage.getAiMessage());
     }
@@ -226,36 +222,6 @@ public class MessageProducer {
     attachmentMessage.setStreamId(symphonyAiMessage.getStreamId());
 
     return symphonyClientUtil.getFileAttachment(attachmentInfo, attachmentMessage);
-  }
-  
-  /**
-   * Parse a message into valid MessageML format
-   * @param message SymphonyAiMessage with the message contents
-   * @return StringBuilder with the output message in MessageML format
-   */
-  private String parseMessage(SymphonyAiMessage message) {
-    Element elementMessageML;
-    StringBuilder textDoc = new StringBuilder("");
-
-    Document doc = Jsoup.parse(message.getMessageData());
-
-    doc.select("errors").remove();
-    elementMessageML = doc.select("messageML").first();
-    if (elementMessageML == null) {
-      elementMessageML = doc.select("div").first();
-    }
-
-    if (elementMessageML != null) {
-      elementMessageML.childNodes().forEach(node -> {
-        if (node.toString().equalsIgnoreCase("<br>")) {
-          textDoc.append("<br/>");
-        } else {
-          textDoc.append(node.toString());
-        }
-      });
-    }
-
-    return textDoc.toString();
   }
 
   /**

--- a/helpdesk-ai/src/test/java/org/symphonyoss/symphony/bots/ai/message/MessageProducerTest.java
+++ b/helpdesk-ai/src/test/java/org/symphonyoss/symphony/bots/ai/message/MessageProducerTest.java
@@ -52,13 +52,13 @@ public class MessageProducerTest {
           + "class=\"entity\" data-entity-id=\"emoji8\">\uD83D\uDE06</span> <span "
           + "class=\"entity\" data-entity-id=\"emoji9\">\uD83D\uDE05</span> <span "
           + "class=\"entity\" data-entity-id=\"emoji10\">\uD83D\uDE03</span> <span "
-          + "class=\"entity\" data-entity-id=\"emoji11\">:rofl:</span> <span class=\"entity\" "
-          + "data-entity-id=\"emoji12\">\uD83C\uDDE8\uD83C\uDDEE</span> <span class=\"entity\" "
-          + "data-entity-id=\"emoji13\">\uD83C\uDDEE\uD83C\uDDE8</span> <span class=\"entity\" "
-          + "data-entity-id=\"emoji14\">\uD83C\uDDF9\uD83C\uDDFB</span> <span class=\"entity\" "
-          + "data-entity-id=\"emoji15\">\uD83C\uDDF9\uD83C\uDDF0</span> <span class=\"entity\" "
-          + "data-entity-id=\"emoji16\">\uD83C\uDDFF\uD83C\uDDFC</span><br/>Finally,"
-          + "<ul><li>we</li><li>have</li><li>a</li><li>bullet</li><li>list</li></ul></div>";
+          + "class=\"entity\" data-entity-id=\"emoji12\">\uD83C\uDDE8\uD83C\uDDEE</span> <span "
+          + "class=\"entity\" data-entity-id=\"emoji13\">\uD83C\uDDEE\uD83C\uDDE8</span> <span "
+          + "class=\"entity\" data-entity-id=\"emoji14\">\uD83C\uDDF9\uD83C\uDDFB</span> <span "
+          + "class=\"entity\" data-entity-id=\"emoji15\">\uD83C\uDDF9\uD83C\uDDF0</span> <span "
+          + "class=\"entity\" data-entity-id=\"emoji16\">\uD83C\uDDFF\uD83C\uDDFC</span><br"
+          + "/>Finally,<ul><li>we</li><li>have</li><li>a</li><li>bullet</li><li>list</li></ul"
+          + "></div>";
   private String COMPLEX_MESSAGE_ENTITY_DATA =
       "{\"emoji1\":{\"type\":\"com.symphony.emoji\",\"version\":\"1.0\",\"data\":{\"short\""
           + ":\"copyright\",\"size\":\"normal\",\"unicode\":\"©\"}},\"emoji2\":{\"type\":\"com"
@@ -167,7 +167,7 @@ public class MessageProducerTest {
     verify(messagesClient).sendMessage(any(SymStream.class), captor.capture());
 
     SymMessage sentMessage = captor.getValue();
-    assertEquals(sentMessage.getMessage(), EXPECTED_BOT_MESSAGE);
+    assertEquals(EXPECTED_BOT_MESSAGE, sentMessage.getMessage());
   }
 
   @Test
@@ -180,7 +180,7 @@ public class MessageProducerTest {
     verify(messagesClient).sendMessage(any(SymStream.class), captor.capture());
 
     SymMessage sentMessage = captor.getValue();
-    assertEquals(sentMessage.getMessage(), EXPECTED_CHIME_MESSAGE);
+    assertEquals(EXPECTED_CHIME_MESSAGE, sentMessage.getMessage());
   }
 
   @Test
@@ -199,7 +199,6 @@ public class MessageProducerTest {
             + "data-entity-id=\"emoji8\">\uD83D\uDE06</span> <span class=\"entity\" "
             + "data-entity-id=\"emoji9\">\uD83D\uDE05</span> <span class=\"entity\" "
             + "data-entity-id=\"emoji10\">\uD83D\uDE03</span> <span class=\"entity\" "
-            + "data-entity-id=\"emoji11\">:rofl:</span> <span class=\"entity\" "
             + "data-entity-id=\"emoji12\">\uD83C\uDDE8\uD83C\uDDEE</span> <span class=\"entity\" "
             + "data-entity-id=\"emoji13\">\uD83C\uDDEE\uD83C\uDDE8</span> <span class=\"entity\" "
             + "data-entity-id=\"emoji14\">\uD83C\uDDF9\uD83C\uDDFB</span> <span class=\"entity\" "
@@ -216,8 +215,8 @@ public class MessageProducerTest {
     verify(messagesClient).sendMessage(any(SymStream.class), captor.capture());
 
     SymMessage sentMessage = captor.getValue();
-    assertEquals(sentMessage.getMessage(), EXPECTED_COMPLEX_MESSAGE);
-    assertEquals(sentMessage.getEntityData(), COMPLEX_MESSAGE_ENTITY_DATA);
+    assertEquals(EXPECTED_COMPLEX_MESSAGE, sentMessage.getMessage());
+    assertEquals(COMPLEX_MESSAGE_ENTITY_DATA, sentMessage.getEntityData());
   }
 
   @Test
@@ -246,7 +245,7 @@ public class MessageProducerTest {
     verify(messagesClient).sendMessage(any(SymStream.class), captor.capture());
 
     SymMessage sentMessage = captor.getValue();
-    assertEquals(sentMessage.getMessage(), EXPECTED_CHIME_MESSAGE);
+    assertEquals(EXPECTED_CHIME_MESSAGE, sentMessage.getMessage());
   }
 
   @Test
@@ -266,13 +265,12 @@ public class MessageProducerTest {
             + "class=\"entity\" data-entity-id=\"emoji8\">\uD83D\uDE06</span> <span "
             + "class=\"entity\" data-entity-id=\"emoji9\">\uD83D\uDE05</span> <span "
             + "class=\"entity\" data-entity-id=\"emoji10\">\uD83D\uDE03</span> <span "
-            + "class=\"entity\" data-entity-id=\"emoji11\">:rofl:</span> <span class=\"entity\" "
-            + "data-entity-id=\"emoji12\">\uD83C\uDDE8\uD83C\uDDEE</span> <span class=\"entity\" "
-            + "data-entity-id=\"emoji13\">\uD83C\uDDEE\uD83C\uDDE8</span> <span class=\"entity\" "
-            + "data-entity-id=\"emoji14\">\uD83C\uDDF9\uD83C\uDDFB</span> <span class=\"entity\" "
-            + "data-entity-id=\"emoji15\">\uD83C\uDDF9\uD83C\uDDF0</span> <span class=\"entity\" "
-            + "data-entity-id=\"emoji16\">\uD83C\uDDFF\uD83C\uDDFC</span><br/>Finally,<ul>\n "
-            + "<li>we</li>\n <li>have</li>\n <li>a</li>\n <li>bullet</li>\n "
+            + "class=\"entity\" data-entity-id=\"emoji12\">\uD83C\uDDE8\uD83C\uDDEE</span> <span "
+            + "class=\"entity\" data-entity-id=\"emoji13\">\uD83C\uDDEE\uD83C\uDDE8</span> <span "
+            + "class=\"entity\" data-entity-id=\"emoji14\">\uD83C\uDDF9\uD83C\uDDFB</span> <span "
+            + "class=\"entity\" data-entity-id=\"emoji15\">\uD83C\uDDF9\uD83C\uDDF0</span> <span "
+            + "class=\"entity\" data-entity-id=\"emoji16\">\uD83C\uDDFF\uD83C\uDDFC</span><br"
+            + "/>Finally,<ul>\n <li>we</li>\n <li>have</li>\n <li>a</li>\n <li>bullet</li>\n "
             + "<li>list</li>\n</ul></messageML>";
     doReturn("CLIENT").when(membership).getType();
     symphonyAiMessage.setMessageData(COMPLEX_MESSAGE);
@@ -283,8 +281,8 @@ public class MessageProducerTest {
     verify(messagesClient).sendMessage(any(SymStream.class), captor.capture());
 
     SymMessage sentMessage = captor.getValue();
-    assertEquals(sentMessage.getMessage(), EXPECTED_USER_COMPLEX_MESSAGE);
-    assertEquals(sentMessage.getEntityData(), COMPLEX_MESSAGE_ENTITY_DATA);
+    assertEquals(EXPECTED_USER_COMPLEX_MESSAGE, sentMessage.getMessage());
+    assertEquals(COMPLEX_MESSAGE_ENTITY_DATA, sentMessage.getEntityData());
   }
 
   @Test

--- a/helpdesk-message-proxy-service/src/main/java/org/symphonyoss/symphony/bots/helpdesk/messageproxy/service/TicketService.java
+++ b/helpdesk-message-proxy-service/src/main/java/org/symphonyoss/symphony/bots/helpdesk/messageproxy/service/TicketService.java
@@ -24,19 +24,14 @@ import org.symphonyoss.symphony.bots.helpdesk.service.model.Ticket;
 import org.symphonyoss.symphony.bots.helpdesk.service.model.UserInfo;
 import org.symphonyoss.symphony.bots.helpdesk.service.ticket.client.TicketClient;
 import org.symphonyoss.symphony.bots.utility.message.SymMessageUtil;
-import org.symphonyoss.symphony.clients.model.SymAttachmentInfo;
 import org.symphonyoss.symphony.clients.model.SymMessage;
 import org.symphonyoss.symphony.clients.model.SymStream;
 import org.symphonyoss.symphony.clients.model.SymUser;
 
-import java.io.BufferedReader;
 import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
-import java.util.List;
 
 
 /**

--- a/helpdesk-message-proxy-service/src/main/java/org/symphonyoss/symphony/bots/helpdesk/messageproxy/service/TicketService.java
+++ b/helpdesk-message-proxy-service/src/main/java/org/symphonyoss/symphony/bots/helpdesk/messageproxy/service/TicketService.java
@@ -168,7 +168,11 @@ public class TicketService {
       return username + " sent a table!";
     }
 
-    return message.getMessageText();
+    if (message.getMessage() != null && message.getEntityData().equals("{}")) {
+      return SymMessageUtil.parseMessage(message);
+    } else {
+      return message.getMessageText();
+    }
   }
 
   public void sendClientMessageToServiceStreamId(String streamId, SymMessage message) {

--- a/helpdesk-message-proxy-service/src/main/java/org/symphonyoss/symphony/bots/helpdesk/messageproxy/service/TicketService.java
+++ b/helpdesk-message-proxy-service/src/main/java/org/symphonyoss/symphony/bots/helpdesk/messageproxy/service/TicketService.java
@@ -23,8 +23,6 @@ import org.symphonyoss.symphony.clients.model.SymMessage;
 import org.symphonyoss.symphony.clients.model.SymStream;
 import org.symphonyoss.symphony.clients.model.SymUser;
 
-import java.io.IOException;
-
 /**
  * Created by rsanchez on 01/12/17.
  */
@@ -175,12 +173,7 @@ public class TicketService {
     }
 
     if (message.getMessage() != null) {
-      try {
-        return SymMessageUtil.parseTicketMessage(message);
-      } catch (IOException e) {
-        LOGGER.error("Could not access message entity data: ", e);
-        return message.getMessageText();
-      }
+      return SymMessageUtil.parseMessage(message);
     } else {
       return message.getMessageText();
     }

--- a/helpdesk-message-proxy-service/src/main/java/org/symphonyoss/symphony/bots/helpdesk/messageproxy/service/TicketService.java
+++ b/helpdesk-message-proxy-service/src/main/java/org/symphonyoss/symphony/bots/helpdesk/messageproxy/service/TicketService.java
@@ -1,11 +1,6 @@
 package org.symphonyoss.symphony.bots.helpdesk.messageproxy.service;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.commons.codec.binary.Base64;
-import org.jsoup.Jsoup;
-import org.jsoup.nodes.Document;
-import org.jsoup.nodes.Element;
-import org.jsoup.nodes.Node;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
@@ -13,7 +8,6 @@ import org.springframework.stereotype.Service;
 import org.symphonyoss.client.SymphonyClient;
 import org.symphonyoss.client.exceptions.MessagesException;
 import org.symphonyoss.client.exceptions.UsersClientException;
-import org.symphonyoss.client.model.NodeTypes;
 import org.symphonyoss.client.model.Room;
 import org.symphonyoss.symphony.bots.helpdesk.messageproxy.config.HelpDeskBotInfo;
 import org.symphonyoss.symphony.bots.helpdesk.messageproxy.config.HelpDeskServiceInfo;
@@ -29,9 +23,6 @@ import org.symphonyoss.symphony.clients.model.SymStream;
 import org.symphonyoss.symphony.clients.model.SymUser;
 
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.LinkedHashMap;
 
 
 /**
@@ -170,68 +161,15 @@ public class TicketService {
     }
 
     if (message.getMessage() != null) {
-      return parseTicketMessage(message);
+      try {
+        return SymMessageUtil.parseTicketMessage(message);
+      } catch (IOException e) {
+        LOGGER.error("Could not access message entity data: ", e);
+        return message.getMessageText();
+      }
     } else {
       return message.getMessageText();
     }
-  }
-
-  /**
-   * Parse the received PresentationML formatted message into a valid MessageML fragment that
-   * will compose the "Question" field of the ticket
-   * @param message The message to be processed
-   * @return String containing the valid MessageML fragment
-   */
-  private String parseTicketMessage(SymMessage message) {
-    Element elementMessageML;
-    StringBuilder textDoc = new StringBuilder("");
-
-    Document doc = Jsoup.parse(message.getMessage());
-
-    doc.select("errors").remove();
-    elementMessageML = doc.select("messageML").first();
-    if (elementMessageML == null) {
-      elementMessageML = doc.select("div").first();
-    }
-
-    if (elementMessageML != null) {
-      for (Node node : elementMessageML.childNodes()) {
-        if (node.nodeName().equalsIgnoreCase("span")) {
-          if (node.attributes().get("class").equalsIgnoreCase("entity")) {
-            String value = node.childNodes().get(0).toString();
-            String statement = "";
-            if (value.startsWith("#")) {
-              statement =
-                  "<" + NodeTypes.HASHTAG.toString() + " tag=\"" + value.substring(1) + "\" />";
-            } else if (value.startsWith("$")) {
-              statement =
-                  "<" + NodeTypes.CASHTAG.toString() + " tag=\"" + value.substring(1) + "\" />";
-            } else if (value.startsWith("@")) {
-              try {
-                LinkedHashMap result = (LinkedHashMap)
-                    new ObjectMapper().readValue(message.getEntityData(), HashMap.class)
-                        .get(node.attributes().get("data-entity-id"));
-                ArrayList<LinkedHashMap> ids = (ArrayList) result.get("id");
-                for (LinkedHashMap id : ids) {
-                  statement +=
-                      "<" + NodeTypes.MENTION.toString() + " uid=\"" + id.get("value").toString()
-                          + "\" />";
-                }
-              } catch (IOException e) {
-                LOGGER.error("Could not get entity data: ", e);
-              }
-            }
-            textDoc.append(statement);
-          }
-        } else if (node.nodeName().equalsIgnoreCase("<br>")) {
-          textDoc.append("<br/>");
-        } else {
-          textDoc.append(node.toString());
-        }
-      }
-    }
-
-    return textDoc.toString();
   }
 
   public void sendClientMessageToServiceStreamId(String streamId, SymMessage message) {

--- a/helpdesk-message-proxy-service/src/test/java/org/symphonyoss/symphony/bots/helpdesk/messageproxy/service/TicketServiceTest.java
+++ b/helpdesk-message-proxy-service/src/test/java/org/symphonyoss/symphony/bots/helpdesk/messageproxy/service/TicketServiceTest.java
@@ -79,7 +79,8 @@ public class TicketServiceTest {
           + "\"id\":[{\"type\":\"com.symphony.user.userId\",\"value\":\"9208409883842\"}]}}";
 
   private static final String EXPECTED_COMPLEX_MESSAGE =
-      "<hash tag=\\\"hash\\\" /> <cash tag=\\\"cash\\\" /> <mention uid=\\\"9208409883842\\\" /> mention "
+      "<hash tag=\\\"hash\\\" /> <cash tag=\\\"cash\\\" /> <mention uid=\\\"9208409883842\\\" /> "
+          + "mention "
           + "<b>bold</b> <i>italic</i> <b><i>combo</i></b><ul>\\n <li>bullet1</li>\\n "
           + "<li>bullet2</li>\\n</ul>";
 

--- a/helpdesk-message-proxy-service/src/test/java/org/symphonyoss/symphony/bots/helpdesk/messageproxy/service/TicketServiceTest.java
+++ b/helpdesk-message-proxy-service/src/test/java/org/symphonyoss/symphony/bots/helpdesk/messageproxy/service/TicketServiceTest.java
@@ -63,6 +63,26 @@ public class TicketServiceTest {
   private static final String TABLE_MESSAGE = "<div data-format=\"PresentationML\"data-version"
       + "=\"2.0\"><table><tr><td>text</td></tr></table></div>";
 
+  private static final String COMPLEX_MESSAGE =
+      "<div data-format=\"PresentationML\" data-version=\"2.0\"><span class=\"entity\" "
+          + "data-entity-id=\"keyword1\">#hash</span> <span class=\"entity\" "
+          + "data-entity-id=\"keyword2\">$cash</span> <span class=\"entity\" "
+          + "data-entity-id=\"mention3\">@HelpDesk</span> mention <b>bold</b> <i>italic</i> "
+          + "<b><i>combo</i></b><ul><li>bullet1</li><li>bullet2</li></ul></div>";
+
+  private static final String COMPLEX_MESSAGE_ENTITY_DATA =
+      "{\"keyword1\":{\"type\":\"org.symphonyoss.taxonomy\",\"version\":\"1.0\","
+          + "\"id\":[{\"type\":\"org.symphonyoss.taxonomy.hashtag\",\"value\":\"hash\"}]},"
+          + "\"keyword2\":{\"type\":\"org.symphonyoss.fin.security\",\"version\":\"1.0\","
+          + "\"id\":[{\"type\":\"org.symphonyoss.fin.security.id.ticker\",\"value\":\"cash\"}]},"
+          + "\"mention3\":{\"type\":\"com.symphony.user.mention\",\"version\":\"1.0\","
+          + "\"id\":[{\"type\":\"com.symphony.user.userId\",\"value\":\"9208409883842\"}]}}";
+
+  private static final String EXPECTED_COMPLEX_MESSAGE =
+      "<hash tag=\\\"hash\\\" /> <cash tag=\\\"cash\\\" /> <mention uid=\\\"9208409883842\\\" /> mention "
+          + "<b>bold</b> <i>italic</i> <b><i>combo</i></b><ul>\\n <li>bullet1</li>\\n "
+          + "<li>bullet2</li>\\n</ul>";
+
   private static final Long TEST_TIMESTAMP = 1L;
 
   private static final Long TEST_FROM_USER_ID = 2L;
@@ -82,7 +102,7 @@ public class TicketServiceTest {
   private SymphonyClient symphonyClient;
 
   @Before
-  public void initMocks(){
+  public void initMocks() {
     MockitoAnnotations.initMocks(this);
 
     when(symphonyClient.getUsersClient()).thenReturn(usersClient);
@@ -164,7 +184,8 @@ public class TicketServiceTest {
     stream.setStreamId(TEST_CLIENT_STREAM_ID);
     when(messagesClient.sendMessage(stream, symMessage)).thenReturn(symMessage);
     stream.setStreamId(TEST_AGENT_STREAM);
-    when(messagesClient.sendMessage(stream, getTestClaimMessage())).thenReturn(getTestClaimMessage());
+    when(messagesClient.sendMessage(stream, getTestClaimMessage())).thenReturn(
+        getTestClaimMessage());
     stream.setStreamId(TEST_SERVICE_STREAM_ID);
     when(messagesClient.sendMessage(stream, getTestInstructionalMessage()))
         .thenReturn(getTestInstructionalMessage());
@@ -174,6 +195,23 @@ public class TicketServiceTest {
     Ticket ticket = ticketService.createTicket(TEST_TICKET_ID, testSym, serviceStream);
 
     assertEquals("Ticket return", mockTicket, ticket);
+  }
+
+  @Test
+  public void testSendComplexTicketMessage() throws UsersClientException, MessagesException {
+    getTestUser();
+
+    SymMessage testSym = getTestSymMessage();
+    testSym.setMessage(COMPLEX_MESSAGE);
+    testSym.setEntityData(COMPLEX_MESSAGE_ENTITY_DATA);
+
+    ticketService.sendTicketMessageToAgentStreamId(mock(Ticket.class), testSym);
+
+    ArgumentCaptor<SymMessage> captor = ArgumentCaptor.forClass(SymMessage.class);
+    verify(messagesClient).sendMessage(any(SymStream.class), captor.capture());
+    SymMessage sentMessage = captor.getValue();
+
+    assertTrue(sentMessage.getEntityData().contains("\"question\":\"" + EXPECTED_COMPLEX_MESSAGE));
   }
 
   @Test
@@ -189,7 +227,8 @@ public class TicketServiceTest {
     verify(messagesClient).sendMessage(any(SymStream.class), captor.capture());
     SymMessage sentMessage = captor.getValue();
 
-    assertTrue(sentMessage.getEntityData().contains("\"question\":\"" + user.getDisplayName() + " sent a chime!\""));
+    assertTrue(sentMessage.getEntityData()
+        .contains("\"question\":\"" + user.getDisplayName() + " sent a chime!\""));
   }
 
   @Test
@@ -210,11 +249,13 @@ public class TicketServiceTest {
     verify(messagesClient).sendMessage(any(SymStream.class), captor.capture());
     SymMessage sentMessage = captor.getValue();
 
-    assertTrue(sentMessage.getEntityData().contains("\"question\":\"" + user.getDisplayName() + " sent an attachment!\""));
+    assertTrue(sentMessage.getEntityData()
+        .contains("\"question\":\"" + user.getDisplayName() + " sent an attachment!\""));
   }
 
   @Test
-  public void testSendTicketMessageWithAttachmentAndText() throws UsersClientException, MessagesException {
+  public void testSendTicketMessageWithAttachmentAndText()
+      throws UsersClientException, MessagesException {
     getTestUser();
     List<SymAttachmentInfo> attachments = new ArrayList<>();
     attachments.add(new SymAttachmentInfo());
@@ -248,7 +289,8 @@ public class TicketServiceTest {
     verify(messagesClient).sendMessage(any(SymStream.class), captor.capture());
     SymMessage sentMessage = captor.getValue();
 
-    assertTrue(sentMessage.getEntityData().contains("\"question\":\"" + user.getDisplayName() + " sent a table!\""));
+    assertTrue(sentMessage.getEntityData()
+        .contains("\"question\":\"" + user.getDisplayName() + " sent a table!\""));
   }
 
   @Test

--- a/helpdesk-message-proxy-service/src/test/java/org/symphonyoss/symphony/bots/helpdesk/messageproxy/service/TicketServiceTest.java
+++ b/helpdesk-message-proxy-service/src/test/java/org/symphonyoss/symphony/bots/helpdesk/messageproxy/service/TicketServiceTest.java
@@ -214,7 +214,7 @@ public class TicketServiceTest {
   }
 
   @Test
-  public void testSendTicketMessageWithText() throws UsersClientException, MessagesException {
+  public void testSendTicketMessageWithAttachmentAndText() throws UsersClientException, MessagesException {
     getTestUser();
     List<SymAttachmentInfo> attachments = new ArrayList<>();
     attachments.add(new SymAttachmentInfo());
@@ -222,6 +222,7 @@ public class TicketServiceTest {
 
     SymMessage testSym = getTestSymMessage();
     testSym.setMessageText(ATTACHMENT_MESSAGE);
+    testSym.setEntityData("{}");
     testSym.setAttachments(attachments);
 
     ticketService.sendTicketMessageToAgentStreamId(mock(Ticket.class), testSym);
@@ -230,7 +231,7 @@ public class TicketServiceTest {
     verify(messagesClient).sendMessage(any(SymStream.class), captor.capture());
     SymMessage sentMessage = captor.getValue();
 
-    assertTrue(sentMessage.getEntityData().contains("\"question\":\"" + ATTACHMENT_MESSAGE));
+    assertTrue(sentMessage.getEntityData().contains("\"question\":\"\\n" + ATTACHMENT_MESSAGE));
   }
 
   @Test

--- a/symphony-utility/src/main/java/org/symphonyoss/symphony/bots/utility/message/SymMessageUtil.java
+++ b/symphony-utility/src/main/java/org/symphonyoss/symphony/bots/utility/message/SymMessageUtil.java
@@ -69,4 +69,34 @@ public class SymMessageUtil {
 
     return elementMessageML != null;
   }
+
+  /**
+   * Parse a message into valid MessageML format
+   * @param message SymphonyAiMessage with the message contents
+   * @return StringBuilder with the output message in MessageML format
+   */
+  public static String parseMessage(SymMessage message) {
+    Element elementMessageML;
+    StringBuilder textDoc = new StringBuilder("");
+
+    Document doc = Jsoup.parse(message.getMessage());
+
+    doc.select("errors").remove();
+    elementMessageML = doc.select("messageML").first();
+    if (elementMessageML == null) {
+      elementMessageML = doc.select("div").first();
+    }
+
+    if (elementMessageML != null) {
+      elementMessageML.childNodes().forEach(node -> {
+        if (node.toString().equalsIgnoreCase("<br>")) {
+          textDoc.append("<br/>");
+        } else {
+          textDoc.append(node.toString());
+        }
+      });
+    }
+
+    return textDoc.toString();
+  }
 }

--- a/symphony-utility/src/main/java/org/symphonyoss/symphony/bots/utility/message/SymMessageUtil.java
+++ b/symphony-utility/src/main/java/org/symphonyoss/symphony/bots/utility/message/SymMessageUtil.java
@@ -1,11 +1,18 @@
 package org.symphonyoss.symphony.bots.utility.message;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Element;
+import org.jsoup.nodes.Node;
+import org.symphonyoss.client.model.NodeTypes;
 import org.symphonyoss.symphony.clients.model.SymAttachmentInfo;
 import org.symphonyoss.symphony.clients.model.SymMessage;
 
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 
 public class SymMessageUtil {
@@ -97,6 +104,95 @@ public class SymMessageUtil {
       });
     }
 
-    return textDoc.toString();
+    return placeEmojis(textDoc.toString());
+  }
+
+  /**
+   * Parse the received PresentationML formatted message into a valid MessageML fragment that
+   * will compose the "Question" field of the ticket
+   * @param message The message to be processed
+   * @return String containing the valid MessageML fragment
+   */
+  public static String parseTicketMessage(SymMessage message) throws IOException {
+    Element elementMessageML;
+    StringBuilder textDoc = new StringBuilder("");
+
+    Document doc = Jsoup.parse(message.getMessage());
+
+    doc.select("errors").remove();
+    elementMessageML = doc.select("messageML").first();
+    if (elementMessageML == null) {
+      elementMessageML = doc.select("div").first();
+    }
+
+    if (elementMessageML != null) {
+      for (Node node : elementMessageML.childNodes()) {
+        if (node.nodeName().equalsIgnoreCase("span")) {
+          if (node.attributes().get("class").equalsIgnoreCase("entity")) {
+            String value = node.childNodes().get(0).toString();
+            String statement = "";
+            if (value.startsWith("#")) {
+              statement =
+                  "<" + NodeTypes.HASHTAG.toString() + " tag=\"" + value.substring(1) + "\" />";
+            } else if (value.startsWith("$")) {
+              statement =
+                  "<" + NodeTypes.CASHTAG.toString() + " tag=\"" + value.substring(1) + "\" />";
+            } else if (value.startsWith("@")) {
+              LinkedHashMap result = (LinkedHashMap)
+                  new ObjectMapper().readValue(message.getEntityData(), HashMap.class)
+                      .get(node.attributes().get("data-entity-id"));
+              ArrayList<LinkedHashMap> ids = (ArrayList) result.get("id");
+              for (LinkedHashMap id : ids) {
+                statement +=
+                    "<" + NodeTypes.MENTION.toString() + " uid=\"" + id.get("value").toString()
+                        + "\" />";
+              }
+            }
+            textDoc.append(statement);
+          }
+        } else if (node.nodeName().equalsIgnoreCase("<br>")) {
+          textDoc.append("<br/>");
+        } else {
+          textDoc.append(node.toString());
+        }
+      }
+    }
+
+    return placeEmojis(textDoc.toString());
+  }
+
+  /**
+   * Verifies a string changing any emoji shortcodes with the correct MessageML emoji tags
+   * @param message String with   the possible emojis
+   * @return String with any emojis processed into MessageML tags
+   */
+  private static String placeEmojis(String message) {
+    StringBuilder result = new StringBuilder();
+    StringBuilder partial = new StringBuilder();
+    boolean possileEmoji = false;
+    for (Character c : message.toCharArray()) {
+      if (possileEmoji) {
+        partial.append(c);
+        if (c == ':') {
+          partial.setLength(partial.length()-1);
+          String shortCode = partial.toString();
+          shortCode = shortCode.substring(1);
+          result.append("<emoji shortcode=\"" + shortCode + "\" />");
+          possileEmoji = false;
+        } else if (!Character.isLetter(c) && !Character.isDigit(c) && c != '_' && c != '-' && c != '+') {
+          possileEmoji = false;
+          result.append(partial);
+        }
+      } else {
+        if (c == ':') {
+          possileEmoji = true;
+          partial.setLength(0);
+          partial.append(c);
+        } else {
+          result.append(c);
+        }
+      }
+    }
+    return result.toString();
   }
 }

--- a/symphony-utility/src/main/java/org/symphonyoss/symphony/bots/utility/message/SymMessageUtil.java
+++ b/symphony-utility/src/main/java/org/symphonyoss/symphony/bots/utility/message/SymMessageUtil.java
@@ -10,10 +10,11 @@ import org.symphonyoss.symphony.clients.model.SymAttachmentInfo;
 import org.symphonyoss.symphony.clients.model.SymMessage;
 
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 public class SymMessageUtil {
 
@@ -95,62 +96,10 @@ public class SymMessageUtil {
     }
 
     if (elementMessageML != null) {
-      elementMessageML.childNodes().forEach(node -> {
-        if (node.toString().equalsIgnoreCase("<br>")) {
-          textDoc.append("<br/>");
-        } else {
-          textDoc.append(node.toString());
-        }
-      });
-    }
-
-    return placeEmojis(textDoc.toString());
-  }
-
-  /**
-   * Parse the received PresentationML formatted message into a valid MessageML fragment that
-   * will compose the "Question" field of the ticket
-   * @param message The message to be processed
-   * @return String containing the valid MessageML fragment
-   */
-  public static String parseTicketMessage(SymMessage message) throws IOException {
-    Element elementMessageML;
-    StringBuilder textDoc = new StringBuilder("");
-
-    Document doc = Jsoup.parse(message.getMessage());
-
-    doc.select("errors").remove();
-    elementMessageML = doc.select("messageML").first();
-    if (elementMessageML == null) {
-      elementMessageML = doc.select("div").first();
-    }
-
-    if (elementMessageML != null) {
       for (Node node : elementMessageML.childNodes()) {
         if (node.nodeName().equalsIgnoreCase("span")) {
-          if (node.attributes().get("class").equalsIgnoreCase("entity")) {
-            String value = node.childNodes().get(0).toString();
-            String statement = "";
-            if (value.startsWith("#")) {
-              statement =
-                  "<" + NodeTypes.HASHTAG.toString() + " tag=\"" + value.substring(1) + "\" />";
-            } else if (value.startsWith("$")) {
-              statement =
-                  "<" + NodeTypes.CASHTAG.toString() + " tag=\"" + value.substring(1) + "\" />";
-            } else if (value.startsWith("@")) {
-              LinkedHashMap result = (LinkedHashMap)
-                  new ObjectMapper().readValue(message.getEntityData(), HashMap.class)
-                      .get(node.attributes().get("data-entity-id"));
-              ArrayList<LinkedHashMap> ids = (ArrayList) result.get("id");
-              for (LinkedHashMap id : ids) {
-                statement +=
-                    "<" + NodeTypes.MENTION.toString() + " uid=\"" + id.get("value").toString()
-                        + "\" />";
-              }
-            }
-            textDoc.append(statement);
-          }
-        } else if (node.nodeName().equalsIgnoreCase("<br>")) {
+          textDoc.append(parseSpan(node, message.getEntityData()));
+        } else if (node.nodeName().equalsIgnoreCase("br")) {
           textDoc.append("<br/>");
         } else {
           textDoc.append(node.toString());
@@ -162,37 +111,68 @@ public class SymMessageUtil {
   }
 
   /**
-   * Verifies a string changing any emoji shortcodes with the correct MessageML emoji tags
-   * @param message String with   the possible emojis
+   * Parse Hashtag, Cashtag and Mention spans in the original PresentationML into valid MessageML
+   * @param node The original PresentationML span node
+   * @param entityData The message's entity data for data fetching in case of mentions
+   * @return String with the parsed span
+   */
+  private static String parseSpan(Node node, String entityData) {
+    if (node.attributes().get("class").equalsIgnoreCase("entity")) {
+      String value = node.childNodes().get(0).toString();
+      StringBuilder parsedSpan = new StringBuilder();
+      if (value.startsWith("#")) {
+        parsedSpan.append("<")
+            .append(NodeTypes.HASHTAG.toString())
+            .append(" tag=\"")
+            .append(value.substring(1))
+            .append("\" />");
+      } else if (value.startsWith("$")) {
+        parsedSpan.append("<")
+            .append(NodeTypes.CASHTAG.toString())
+            .append(" tag=\"")
+            .append(value.substring(1))
+            .append("\" />");
+      } else if (value.startsWith("@")) {
+        try {
+          LinkedHashMap<String, Object> result = (LinkedHashMap<String, Object>)
+              new ObjectMapper().readValue(entityData, HashMap.class)
+                  .get(node.attributes().get("data-entity-id"));
+          List<LinkedHashMap> ids = (List<LinkedHashMap>) result.get("id");
+          for (LinkedHashMap id : ids) {
+            parsedSpan.append("<")
+                .append(NodeTypes.MENTION.toString())
+                .append(" uid=\"")
+                .append(id.get("value").toString())
+                .append("\" />");
+          }
+        } catch (IOException e) {
+          parsedSpan.append(value);
+        }
+      } else {
+        return node.toString();
+      }
+      return parsedSpan.toString();
+    }
+    return node.toString();
+  }
+
+  /**
+   * Verify a string changing any emoji shortcodes with the correct MessageML emoji tags
+   * @param message String with the possible emojis
    * @return String with any emojis processed into MessageML tags
    */
   private static String placeEmojis(String message) {
-    StringBuilder result = new StringBuilder();
-    StringBuilder partial = new StringBuilder();
-    boolean possileEmoji = false;
-    for (Character c : message.toCharArray()) {
-      if (possileEmoji) {
-        partial.append(c);
-        if (c == ':') {
-          partial.setLength(partial.length()-1);
-          String shortCode = partial.toString();
-          shortCode = shortCode.substring(1);
-          result.append("<emoji shortcode=\"" + shortCode + "\" />");
-          possileEmoji = false;
-        } else if (!Character.isLetter(c) && !Character.isDigit(c) && c != '_' && c != '-' && c != '+') {
-          possileEmoji = false;
-          result.append(partial);
-        }
-      } else {
-        if (c == ':') {
-          possileEmoji = true;
-          partial.setLength(0);
-          partial.append(c);
-        } else {
-          result.append(c);
-        }
-      }
+    StringBuffer result = new StringBuffer();
+    Matcher matcher = Pattern.compile(":([a-z0-9_+-]+):").matcher(message);
+
+    if (!matcher.find()) {
+      return message;
+    } else {
+      do {
+        matcher.appendReplacement(result, "<emoji shortcode=\"" + matcher.group(1) + "\" />");
+      } while (matcher.find());
     }
+
     return result.toString();
   }
 }

--- a/symphony-utility/src/test/java/org/symphonyoss/symphony/bots/utility/message/SymMessageUtilTest.java
+++ b/symphony-utility/src/test/java/org/symphonyoss/symphony/bots/utility/message/SymMessageUtilTest.java
@@ -22,8 +22,25 @@ public class SymMessageUtilTest {
   private static final String TABLE_MESSAGE = "<div data-format=\"PresentationML\"data-version"
       + "=\"2.0\"><table><tr><td>text</td></tr></table></div>";
 
+  private static final String EMOJI_MESSAGE =
+      "<div data-format=\"PresentationML\" data-version=\"2.0\">Emoji: :joy:  No emoji: just "
+          + "colon but no emoji : : : yayy: :891 lastly, new emoji: :end:</div>";
+
+  private static final String EXPECTED_EMOJI_MESSAGE =
+      "\nEmoji: <emoji shortcode=\"joy\" /> No emoji: just colon but no emoji : : : yayy: :891 "
+          + "lastly, new emoji: <emoji shortcode=\"end\" />";
+
   @Before
   public void init() {
+  }
+
+  @Test
+  public void testEmojis() {
+    SymMessage testMessage = new SymMessage();
+
+    testMessage.setMessage(EMOJI_MESSAGE);
+
+    assertTrue(SymMessageUtil.parseMessage(testMessage).equals(EXPECTED_EMOJI_MESSAGE));
   }
 
   @Test

--- a/symphony-utility/src/test/java/org/symphonyoss/symphony/bots/utility/message/SymMessageUtilTest.java
+++ b/symphony-utility/src/test/java/org/symphonyoss/symphony/bots/utility/message/SymMessageUtilTest.java
@@ -23,8 +23,8 @@ public class SymMessageUtilTest {
       + "=\"2.0\"><table><tr><td>text</td></tr></table></div>";
 
   private static final String EMOJI_MESSAGE =
-      "<div data-format=\"PresentationML\" data-version=\"2.0\">Emoji: :joy:  No emoji: just "
-          + "colon but no emoji : : : yayy: :891 lastly, new emoji: :end:</div>";
+      "<div data-format=\"PresentationML\"data-version=\"2.0\">Emoji: :joy: No emoji: just colon "
+          + "but no emoji : : : yayy: :891 lastly, new emoji: :end:</div>";
 
   private static final String EXPECTED_EMOJI_MESSAGE =
       "\nEmoji: <emoji shortcode=\"joy\" /> No emoji: just colon but no emoji : : : yayy: :891 "


### PR DESCRIPTION
This PR covers tasks APP-1696 and APP-1697:

Changes covered by APP-1696:
- Adds emoji shortcode support in client, service and queue room messages

Changes covered by APP-1697:
Support for non plain text rendering in new Ticket cards in the queue room.
It adds support for 
- Styled texts: bullet lists, bold text, italic text and hyperlinks.
- Entities: cashtags, hashtags and mentions.