### PR TITLE
APP-1684 Join Conversation link now shows when another agent claims ticket

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,12 @@ After that, you must run the **create_agent_room.sh** script providing the envir
 - Execute HelpDeskBot configuration
 - Execute HelpDeskRenderer configuration
 
+### Command Line
+- It's possible to run the Helpdesk Renderer app in watch mode:
+1. Go to the 'helpdesk-dynamic-rendering' directory.
+2. Execute ```npm run watch```.
+3. Access the helpdesk-renderer URL to validate if it's served properly as described below.
+
 ### Validate applications
 
 - Access this in your Chrome browser: 'chrome://flags/#allow-insecure-localhost'. You should see highlighted

--- a/helpdesk-bot/src/main/java/org/symphonyoss/symphony/bots/helpdesk/bot/ticket/AcceptTicketService.java
+++ b/helpdesk-bot/src/main/java/org/symphonyoss/symphony/bots/helpdesk/bot/ticket/AcceptTicketService.java
@@ -14,6 +14,7 @@ import org.symphonyoss.symphony.bots.ai.model.AiSessionKey;
 import org.symphonyoss.symphony.bots.helpdesk.bot.config.HelpDeskBotConfig;
 import org.symphonyoss.symphony.bots.helpdesk.bot.model.TicketResponse;
 import org.symphonyoss.symphony.bots.helpdesk.bot.util.ValidateMembershipService;
+import org.symphonyoss.symphony.bots.helpdesk.messageproxy.config.HelpDeskBotInfo;
 import org.symphonyoss.symphony.bots.helpdesk.messageproxy.message.AcceptMessageBuilder;
 import org.symphonyoss.symphony.bots.helpdesk.service.model.Ticket;
 import org.symphonyoss.symphony.bots.helpdesk.service.model.UserInfo;
@@ -45,12 +46,16 @@ public class AcceptTicketService extends TicketService {
 
   private final HelpDeskAi helpDeskAi;
 
+  private final HelpDeskBotInfo helpDeskBotInfo;
+
   public AcceptTicketService(SymphonyValidationUtil symphonyValidationUtil,
       SymphonyClient symphonyClient, HelpDeskBotConfig helpDeskBotConfig, TicketClient ticketClient,
-      HelpDeskAi helpDeskAi, ValidateMembershipService validateMembershipService) {
+      HelpDeskAi helpDeskAi, ValidateMembershipService validateMembershipService,
+      HelpDeskBotInfo helpDeskBotInfo) {
     super(symphonyValidationUtil, symphonyClient, helpDeskBotConfig, ticketClient,
         validateMembershipService);
     this.helpDeskAi = helpDeskAi;
+    this.helpDeskBotInfo = helpDeskBotInfo;
   }
 
   /**
@@ -137,6 +142,8 @@ public class AcceptTicketService extends TicketService {
     SymMessage acceptMessage = new AcceptMessageBuilder()
         .agent(userInfo)
         .ticketState(ticketState.getState())
+        .streamId(ticket.getServiceStreamId())
+        .botHost(helpDeskBotInfo.getUrl())
         .ticketId(ticket.getId())
         .build();
 

--- a/helpdesk-bot/src/main/java/org/symphonyoss/symphony/bots/helpdesk/bot/ticket/AcceptTicketService.java
+++ b/helpdesk-bot/src/main/java/org/symphonyoss/symphony/bots/helpdesk/bot/ticket/AcceptTicketService.java
@@ -14,7 +14,6 @@ import org.symphonyoss.symphony.bots.ai.model.AiSessionKey;
 import org.symphonyoss.symphony.bots.helpdesk.bot.config.HelpDeskBotConfig;
 import org.symphonyoss.symphony.bots.helpdesk.bot.model.TicketResponse;
 import org.symphonyoss.symphony.bots.helpdesk.bot.util.ValidateMembershipService;
-import org.symphonyoss.symphony.bots.helpdesk.messageproxy.config.HelpDeskBotInfo;
 import org.symphonyoss.symphony.bots.helpdesk.messageproxy.message.AcceptMessageBuilder;
 import org.symphonyoss.symphony.bots.helpdesk.service.model.Ticket;
 import org.symphonyoss.symphony.bots.helpdesk.service.model.UserInfo;

--- a/helpdesk-bot/src/main/java/org/symphonyoss/symphony/bots/helpdesk/bot/ticket/AcceptTicketService.java
+++ b/helpdesk-bot/src/main/java/org/symphonyoss/symphony/bots/helpdesk/bot/ticket/AcceptTicketService.java
@@ -46,16 +46,12 @@ public class AcceptTicketService extends TicketService {
 
   private final HelpDeskAi helpDeskAi;
 
-  private final HelpDeskBotInfo helpDeskBotInfo;
-
   public AcceptTicketService(SymphonyValidationUtil symphonyValidationUtil,
       SymphonyClient symphonyClient, HelpDeskBotConfig helpDeskBotConfig, TicketClient ticketClient,
-      HelpDeskAi helpDeskAi, ValidateMembershipService validateMembershipService,
-      HelpDeskBotInfo helpDeskBotInfo) {
+      HelpDeskAi helpDeskAi, ValidateMembershipService validateMembershipService) {
     super(symphonyValidationUtil, symphonyClient, helpDeskBotConfig, ticketClient,
         validateMembershipService);
     this.helpDeskAi = helpDeskAi;
-    this.helpDeskBotInfo = helpDeskBotInfo;
   }
 
   /**
@@ -143,7 +139,7 @@ public class AcceptTicketService extends TicketService {
         .agent(userInfo)
         .ticketState(ticketState.getState())
         .streamId(ticket.getServiceStreamId())
-        .botHost(helpDeskBotInfo.getUrl())
+        .botHost(helpDeskBotConfig.getHelpDeskBotUrl())
         .ticketId(ticket.getId())
         .build();
 

--- a/helpdesk-bot/src/test/java/org/symphonyoss/symphony/bots/helpdesk/bot/ticket/AcceptTicketServiceTest.java
+++ b/helpdesk-bot/src/test/java/org/symphonyoss/symphony/bots/helpdesk/bot/ticket/AcceptTicketServiceTest.java
@@ -24,6 +24,7 @@ import org.symphonyoss.symphony.bots.helpdesk.bot.config.HelpDeskBotConfig;
 import org.symphonyoss.symphony.bots.helpdesk.bot.model.TicketResponse;
 import org.symphonyoss.symphony.bots.helpdesk.bot.model.User;
 import org.symphonyoss.symphony.bots.helpdesk.bot.util.ValidateMembershipService;
+import org.symphonyoss.symphony.bots.helpdesk.messageproxy.config.HelpDeskBotInfo;
 import org.symphonyoss.symphony.bots.helpdesk.service.membership.client.MembershipClient;
 import org.symphonyoss.symphony.bots.helpdesk.service.model.Ticket;
 import org.symphonyoss.symphony.bots.helpdesk.service.model.UserInfo;
@@ -103,6 +104,9 @@ public class AcceptTicketServiceTest {
   @Mock
   private ValidateMembershipService validateMembershipService;
 
+  @Mock
+  private HelpDeskBotInfo helpDeskBotInfo;
+
   private AcceptTicketService acceptTicketService;
 
   @Before
@@ -112,7 +116,8 @@ public class AcceptTicketServiceTest {
 
     this.acceptTicketService =
         new AcceptTicketService(symphonyValidationUtil, symphonyClient,
-            helpDeskBotConfig, ticketClient, helpDeskAi, validateMembershipService);
+            helpDeskBotConfig, ticketClient, helpDeskAi, validateMembershipService,
+            helpDeskBotInfo);
   }
 
   @Test
@@ -181,7 +186,8 @@ public class AcceptTicketServiceTest {
 
     doReturn(messagesClient).when(symphonyClient).getMessagesClient();
     doReturn(mockMessages()).when(messagesClient)
-        .getMessagesFromStream(any(SymStream.class), eq(ticket.getQuestionTimestamp()), eq(0), eq(100));
+        .getMessagesFromStream(any(SymStream.class), eq(ticket.getQuestionTimestamp()), eq(0),
+            eq(100));
 
     acceptTicketService.sendTicketHistory(ticket, MOCK_CLIENT_ID);
 

--- a/helpdesk-bot/src/test/java/org/symphonyoss/symphony/bots/helpdesk/bot/ticket/AcceptTicketServiceTest.java
+++ b/helpdesk-bot/src/test/java/org/symphonyoss/symphony/bots/helpdesk/bot/ticket/AcceptTicketServiceTest.java
@@ -116,8 +116,7 @@ public class AcceptTicketServiceTest {
 
     this.acceptTicketService =
         new AcceptTicketService(symphonyValidationUtil, symphonyClient,
-            helpDeskBotConfig, ticketClient, helpDeskAi, validateMembershipService,
-            helpDeskBotInfo);
+            helpDeskBotConfig, ticketClient, helpDeskAi, validateMembershipService);
   }
 
   @Test

--- a/helpdesk-dynamic-rendering/package.json
+++ b/helpdesk-dynamic-rendering/package.json
@@ -57,6 +57,7 @@
   "dependencies": {
     "axios": "^0.15.3",
     "babel-polyfill": "^6.23.0",
+    "base64-url": "^2.2.0",
     "handlebars-loader": "^1.5.0",
     "symphony-integration-commons": "0.1.30"
   },

--- a/helpdesk-dynamic-rendering/src/main/webapp/enrichers/actionClaimTicketEnricher.js
+++ b/helpdesk-dynamic-rendering/src/main/webapp/enrichers/actionClaimTicketEnricher.js
@@ -1,9 +1,12 @@
 import { MessageEnricherBase } from 'symphony-integration-commons';
+import { getUserId, getRooms } from '../utils/userUtils';
 import actionFactory from '../utils/actionFactory';
 
 const actions = require('../templates/claimTicketActions.hbs');
+const base64 = require('base64-url');
 
 const enricherServiceName = 'helpdesk-action-claim-enricher';
+const updatedEnricherServiceName = 'helpdesk-enricher';
 const messageEvents = [
   'com.symphony.bots.helpdesk.event.ticket.accept',
 ];
@@ -17,14 +20,39 @@ export default class ActionClaimTicketEnricher extends MessageEnricherBase {
     const claimedTicket = entity.state === 'UNRESOLVED' || entity.state === 'RESOLVED';
 
     if (claimedTicket) {
-      const data = actionFactory([], enricherServiceName, entity);
-      const entityRegistry = SYMPHONY.services.subscribe('entity');
-      const displayName = entity.agent !== null ? entity.agent.displayName : '';
-      const template = actions({ showClaim: false,
-        resolved: entity.state === 'RESOLVED',
-        userName: displayName });
+      getUserId().then((userId) => {
+        const joinConversationAction = {
+          id: 'joinConversation',
+          service: updatedEnricherServiceName,
+          type: 'joinConversation',
+          label: 'Join the conversation',
+          enricherInstanceId: entity.ticketId,
+          show: entity.state === 'UNSERVICED',
+          userName: entity.agent.displayName,
+          streamId: entity.streamId,
+          userId,
+        };
 
-      entityRegistry.updateEnricher(entity.ticketId, template, data);
+        getRooms().then((userRooms) => {
+          let inRoom = false;
+          userRooms.forEach((room) => {
+            if (base64.escape(room.threadId) === entity.streamId) {
+              inRoom = true;
+            }
+          });
+
+          const data = actionFactory([joinConversationAction], updatedEnricherServiceName, entity);
+          const entityRegistry = SYMPHONY.services.subscribe('entity');
+          const displayName = entity.agent !== null ? entity.agent.displayName : '';
+          const template = actions({ showClaim: false,
+            resolved: entity.state === 'RESOLVED',
+            userName: displayName,
+            inRoom,
+          });
+
+          entityRegistry.updateEnricher(entity.ticketId, template, data);
+        });
+      });
     }
   }
 

--- a/helpdesk-dynamic-rendering/src/main/webapp/enrichers/claimTicketEnricher.js
+++ b/helpdesk-dynamic-rendering/src/main/webapp/enrichers/claimTicketEnricher.js
@@ -43,7 +43,7 @@ export default class ClaimTicketEnricher extends MessageEnricherBase {
       ticket = rsp.data;
       return Promise.all([getUserId(), getRooms()]);
     }).then(userInfo =>
-    this.showTicketRenderer(entity, ticket, userInfo[0], userInfo[1])
+      this.showTicketRenderer(entity, ticket, userInfo[0], userInfo[1])
     ).catch((e) => {
       if (e.messageException === undefined) {
         return renderErrorMessage(entity, 'Cannot retrieve ticket state.', enricherServiceName);
@@ -87,10 +87,10 @@ export default class ClaimTicketEnricher extends MessageEnricherBase {
       actionObjs.push(joinConversationAction);
     }
 
-    let inRoom = false;
+    let isTicketRoomMember = false;
     userRooms.forEach((room) => {
       if (base64.escape(room.threadId) === ticket.serviceStreamId) {
-        inRoom = true;
+        isTicketRoomMember = true;
       }
     });
 
@@ -100,7 +100,7 @@ export default class ClaimTicketEnricher extends MessageEnricherBase {
       template: actions({ showClaim: data.claimTicket.data.show,
         userName: data.claimTicket.data.userName,
         resolved: ticket.state === 'RESOLVED',
-        inRoom,
+        isTicketRoomMember,
       }),
       data,
       enricherInstanceId: entity.ticketId,
@@ -134,7 +134,7 @@ export default class ClaimTicketEnricher extends MessageEnricherBase {
       const template = actions({ showClaim: dataUpdate.claimTicket.data.show,
         resolved: rsp.data.state === 'RESOLVED',
         userName: dataUpdate.claimTicket.data.userName,
-        inRoom: true });
+        isTicketRoomMember: true });
 
       entityRegistry.updateEnricher(data.enricherInstanceId, template, dataUpdate);
     });
@@ -157,7 +157,7 @@ export default class ClaimTicketEnricher extends MessageEnricherBase {
       const template = actions({ showClaim: false,
         resolved: rsp.data.state === 'RESOLVED',
         userName: dataUpdate.joinConversation.data.userName,
-        inRoom: true });
+        isTicketRoomMember: true });
 
       entityRegistry.updateEnricher(data.enricherInstanceId, template, dataUpdate);
     });

--- a/helpdesk-dynamic-rendering/src/main/webapp/enrichers/claimTicketEnricher.js
+++ b/helpdesk-dynamic-rendering/src/main/webapp/enrichers/claimTicketEnricher.js
@@ -1,10 +1,11 @@
 import { MessageEnricherBase } from 'symphony-integration-commons';
 import actionFactory from '../utils/actionFactory';
 import TicketService from '../services/ticketService';
-import { getUserId } from '../utils/userUtils';
+import { getUserId, getRooms } from '../utils/userUtils';
 import { renderErrorMessage } from '../utils/errorMessage';
 
 const actions = require('../templates/claimTicketActions.hbs');
+const base64 = require('base64-url');
 
 const enricherServiceName = 'helpdesk-enricher';
 const messageEvents = [
@@ -40,9 +41,9 @@ export default class ClaimTicketEnricher extends MessageEnricherBase {
       }
 
       ticket = rsp.data;
-      return getUserId();
-    }).then(userId =>
-      this.showTicketRenderer(entity, ticket, userId)
+      return Promise.all([getUserId(), getRooms()]);
+    }).then(userInfo =>
+    this.showTicketRenderer(entity, ticket, userInfo[0], userInfo[1])
     ).catch((e) => {
       if (e.messageException === undefined) {
         return renderErrorMessage(entity, 'Cannot retrieve ticket state.', enricherServiceName);
@@ -52,7 +53,7 @@ export default class ClaimTicketEnricher extends MessageEnricherBase {
     });
   }
 
-  showTicketRenderer(entity, ticket, userId) {
+  showTicketRenderer(entity, ticket, userId, userRooms) {
     const agent = ticket.agent;
     const displayName = agent && agent.displayName ? agent.displayName : '';
 
@@ -86,12 +87,20 @@ export default class ClaimTicketEnricher extends MessageEnricherBase {
       actionObjs.push(joinConversationAction);
     }
 
+    let inRoom = false;
+    userRooms.forEach((room) => {
+      if (base64.escape(room.threadId) === ticket.serviceStreamId) {
+        inRoom = true;
+      }
+    });
+
     const data = actionFactory(actionObjs, enricherServiceName, entity);
 
     const result = {
       template: actions({ showClaim: data.claimTicket.data.show,
         userName: data.claimTicket.data.userName,
         resolved: ticket.state === 'RESOLVED',
+        inRoom,
       }),
       data,
       enricherInstanceId: entity.ticketId,
@@ -122,15 +131,35 @@ export default class ClaimTicketEnricher extends MessageEnricherBase {
       };
 
       const dataUpdate = actionFactory([claimTicketAction], enricherServiceName, data.entity);
-      const template = actions({ showClaim: dataUpdate.claimTicket.data.showClaim,
+      const template = actions({ showClaim: dataUpdate.claimTicket.data.show,
         resolved: rsp.data.state === 'RESOLVED',
-        userName: dataUpdate.claimTicket.data.userName });
+        userName: dataUpdate.claimTicket.data.userName,
+        inRoom: true });
 
       entityRegistry.updateEnricher(data.enricherInstanceId, template, dataUpdate);
     });
   }
 
   join(data) {
-    this.services.ticketService.join(data);
+    this.services.ticketService.join(data).then((rsp) => {
+      const entityRegistry = SYMPHONY.services.subscribe('entity');
+      const joinConversationAction = {
+        id: 'joinConversation',
+        service: enricherServiceName,
+        type: 'joinConversation',
+        label: 'Join the conversation',
+        enricherInstanceId: rsp.data.ticketId,
+        show: rsp.data.state === 'UNSERVICED',
+        userName: rsp.data.user.displayName,
+      };
+
+      const dataUpdate = actionFactory([joinConversationAction], enricherServiceName, data.entity);
+      const template = actions({ showClaim: false,
+        resolved: rsp.data.state === 'RESOLVED',
+        userName: dataUpdate.joinConversation.data.userName,
+        inRoom: true });
+
+      entityRegistry.updateEnricher(data.enricherInstanceId, template, dataUpdate);
+    });
   }
 }

--- a/helpdesk-dynamic-rendering/src/main/webapp/templates/claimTicketActions.hbs
+++ b/helpdesk-dynamic-rendering/src/main/webapp/templates/claimTicketActions.hbs
@@ -6,8 +6,8 @@
         {{#if resolved}}
             <label class="label">This ticket is closed.</label>
         {{else}}
-            {{#if inRoom}}
-                <label class="label">You are in this ticket room.</label>
+            {{#if isTicketRoomMember}}
+                <label class="label">You are a member of this ticket's room.</label>
             {{else}}
                 <action id="joinConversation" class="tempo-text-color--link"/>
             {{/if}}

--- a/helpdesk-dynamic-rendering/src/main/webapp/templates/claimTicketActions.hbs
+++ b/helpdesk-dynamic-rendering/src/main/webapp/templates/claimTicketActions.hbs
@@ -6,7 +6,11 @@
         {{#if resolved}}
             <label class="label">This ticket is closed.</label>
         {{else}}
-            <action id="joinConversation" class="tempo-text-color--link"/>
+            {{#if inRoom}}
+                <label class="label">You are in this ticket room.</label>
+            {{else}}
+                <action id="joinConversation" class="tempo-text-color--link"/>
+            {{/if}}
         {{/if}}
     {{/if}}
 </messageML>

--- a/helpdesk-dynamic-rendering/src/main/webapp/utils/userUtils.js
+++ b/helpdesk-dynamic-rendering/src/main/webapp/utils/userUtils.js
@@ -2,3 +2,8 @@ export const getUserId = () => {
   const extendedUserService = SYMPHONY.services.subscribe('extended-user-service');
   return extendedUserService.getUserId();
 };
+
+export const getRooms = () => {
+  const extendedUserService = SYMPHONY.services.subscribe('extended-user-service');
+  return extendedUserService.getRooms();
+};

--- a/helpdesk-dynamic-rendering/webpack.config.js
+++ b/helpdesk-dynamic-rendering/webpack.config.js
@@ -59,5 +59,15 @@ module.exports = {
     new webpack.optimize.DedupePlugin(),
     new webpack.optimize.UglifyJsPlugin(),
     new webpack.optimize.AggressiveMergingPlugin()
-  ]
+  ],
+  devServer: {
+    contentBase: path.resolve(__dirname, './target/static'),
+    port: 8100,
+    inline: true,
+    headers: {
+      "Access-Control-Allow-Origin": "*"
+    },
+    disableHostCheck: true,
+    publicPath: "/helpdesk-renderer/"
+  }
 };

--- a/helpdesk-message-proxy-service/src/main/java/org/symphonyoss/symphony/bots/helpdesk/messageproxy/message/AcceptMessageBuilder.java
+++ b/helpdesk-message-proxy-service/src/main/java/org/symphonyoss/symphony/bots/helpdesk/messageproxy/message/AcceptMessageBuilder.java
@@ -25,6 +25,10 @@ public class AcceptMessageBuilder extends TicketMessageBuilder {
 
   private String ticketState;
 
+  private String streamId;
+
+  private String botHost;
+
   public AcceptMessageBuilder agent(UserInfo agent) {
     this.agent = agent;
     return this;
@@ -32,6 +36,16 @@ public class AcceptMessageBuilder extends TicketMessageBuilder {
 
   public AcceptMessageBuilder ticketState(String ticketState) {
     this.ticketState = ticketState;
+    return this;
+  }
+
+  public AcceptMessageBuilder streamId(String streamId) {
+    this.streamId = streamId;
+    return this;
+  }
+
+  public AcceptMessageBuilder botHost(String botHost) {
+    this.botHost = botHost;
     return this;
   }
 
@@ -50,6 +64,10 @@ public class AcceptMessageBuilder extends TicketMessageBuilder {
 
     bodyBuilder.addField("ticketId", ticketId);
     bodyBuilder.addField("state", ticketState);
+    bodyBuilder.addField("streamId", streamId);
+
+    String joinUrl = String.format("%s/v1/ticket/%s/join", botHost, ticketId);
+    bodyBuilder.addField("joinUrl", joinUrl);
 
     EntityBuilder userBuilder = EntityBuilder.createEntity(USER_TICKET_EVENT, VERSION);
     userBuilder.addField("displayName", agent.getDisplayName());

--- a/helpdesk-message-proxy-service/src/test/java/org/symphonyoss/symphony/bots/helpdesk/messageproxy/message/AcceptMessageBuilderTest.java
+++ b/helpdesk-message-proxy-service/src/test/java/org/symphonyoss/symphony/bots/helpdesk/messageproxy/message/AcceptMessageBuilderTest.java
@@ -20,7 +20,8 @@ public class AcceptMessageBuilderTest {
 
   private static final String EXPECTED_ENTITY = "{\"helpdesk\":{\"type\":\"com.symphony.bots"
       + ".helpdesk.event.ticket.accept\",\"version\":\"1.0\",\"ticketId\":\"ABCDEFG\","
-      + "\"state\":\"UNRESOLVED\",\"agent\":{\"type\":\"com.symphony.bots.helpdesk.event.ticket"
+      + "\"state\":\"UNRESOLVED\",\"joinUrl\":\"http://localhost:8001/helpdesk-bot/v1/ticket"
+      + "/ABCDEFG/join\",\"agent\":{\"type\":\"com.symphony.bots.helpdesk.event.ticket"
       + ".user\",\"version\":\"1.0\",\"displayName\":\"Agent User\"}}}";
 
   @Test
@@ -28,10 +29,12 @@ public class AcceptMessageBuilderTest {
     AcceptMessageBuilder acceptMessageBuilder = new AcceptMessageBuilder();
     String expectedMessage = acceptMessageBuilder.getMessageTemplate();
 
-    SymMessage symMessage = acceptMessageBuilder.ticketState(TicketClient.TicketStateType.UNRESOLVED.getState())
-        .agent(mockUserInfo())
-        .ticketId(MOCK_TICKET)
-        .build();
+    SymMessage symMessage =
+        acceptMessageBuilder.ticketState(TicketClient.TicketStateType.UNRESOLVED.getState())
+            .agent(mockUserInfo())
+            .ticketId(MOCK_TICKET)
+            .botHost("http://localhost:8001/helpdesk-bot")
+            .build();
 
     assertEquals(expectedMessage, symMessage.getMessage());
     assertEquals(EXPECTED_ENTITY, symMessage.getEntityData());


### PR DESCRIPTION
New features:
- This PR aims to fix the incomplete enriched message when agent A is in queue room and agent B claims a ticket in that room.
- It also changes the enriched message in case the current agent is already in the service room, replacing the "Join Conversation" link for a message "You are already in this room".
- There is also a quality of life improvement for the front-end application Helpdesk-Renderer: it now supports npm run watch for dynamic updates in code.

File changes:
- package.json : Included base64-url lib for making a url-safe string in the front-end. This will be used to check if the agent is in a service room.
- webpack.config.js : Now supports live code update
- AcceptTicketService.java, AcceptMessageBuilder.java : Now includes the bot host URL and streamId in the entity message so the front-end knows where to redirect the agent and what to render.
- actionClaimTicketEnricher.js : Now builds the proper action to be sent to the enricher template.
- claimTicketEnricher.js : Now checks if agent is in room to enrich the message accordingly. Also updates the enricher after a "joinConversation" action (Join conversattion link is clicked).
- claimTicketActions.hbs : Added support for a new message "You are already in this ticket room".
- userUtils.js : Now also exposes the extensions-api call "getRooms".
- AcceptTicketServiceTest.java, AcceptMessageBuilderTest.java : Refactored unit tests accordingly to the new changes in the back-end.