### PR TITLE
APP-1713 Fixed service room creation with exceeding characters

### DIFF
--- a/helpdesk-message-proxy-service/src/main/java/org/symphonyoss/symphony/bots/helpdesk/messageproxy/service/RoomService.java
+++ b/helpdesk-message-proxy-service/src/main/java/org/symphonyoss/symphony/bots/helpdesk/messageproxy/service/RoomService.java
@@ -16,6 +16,12 @@ public class RoomService {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(RoomService.class);
 
+  private static final int MAX_TAGS_SIZE = 21;
+
+  private static final int MAX_PODNAME_SIZE = 11;
+
+  private static final int MAX_GROUPID_SIZE = 24;
+
   private final SymphonyClient symphonyClient;
 
   public RoomService(SymphonyClient symphonyClient) {
@@ -59,17 +65,13 @@ public class RoomService {
    * @return the built Room Name
    */
   private String buildRoomName(String podName, String groupId, String ticketId) {
-    int availableChars = 50 - ("[] Ticket Room #" + ticketId).length();
-
     if (podName != null) {
-      availableChars -= "[] ".length();
+      String podNameNormalized = truncate(podName, MAX_PODNAME_SIZE);
+      String groupIdNormalized = truncate(groupId, MAX_TAGS_SIZE - podNameNormalized.length());
 
-      podName = truncate(podName, Math.max(availableChars / 2, availableChars - groupId.length()));
-      groupId = truncate(groupId, availableChars - podName.length());
-
-      return "[" + podName + "] [" + groupId + "] Ticket Room #" + ticketId;
+      return "[" + podNameNormalized + "] [" + groupIdNormalized + "] Ticket Room #" + ticketId;
     } else {
-      groupId = truncate(groupId, availableChars);
+      groupId = truncate(groupId, MAX_GROUPID_SIZE);
 
       return "[" + groupId + "] Ticket Room #" + ticketId;
     }
@@ -77,15 +79,15 @@ public class RoomService {
 
   /**
    * Truncates a string with a given length
-   * @param string the string to be truncated
+   * @param value the string to be truncated
    * @param length the maximum length
    * @return the truncated string
    */
-  private String truncate(String string, int length) {
-    if (string.length() > length) {
-      return string.substring(0, length);
+  private String truncate(String value, int length) {
+    if (value.length() > length) {
+      return value.substring(0, length).trim();
     } else {
-      return string;
+      return value;
     }
   }
 

--- a/helpdesk-message-proxy-service/src/main/java/org/symphonyoss/symphony/bots/helpdesk/messageproxy/service/RoomService.java
+++ b/helpdesk-message-proxy-service/src/main/java/org/symphonyoss/symphony/bots/helpdesk/messageproxy/service/RoomService.java
@@ -24,7 +24,6 @@ public class RoomService {
 
   /**
    * Creates a new service stream for a ticket.
-   *
    * @param ticketId the ticket ID to create the service stream for
    * @param groupId group Id
    * @param podName Pod Name
@@ -35,18 +34,12 @@ public class RoomService {
       Boolean viewHistory)
       throws RoomException {
     SymRoomAttributes roomAttributes = new SymRoomAttributes();
-    roomAttributes.setCreatorUser(symphonyClient.getLocalUser());
 
+    roomAttributes.setCreatorUser(symphonyClient.getLocalUser());
     roomAttributes.setDescription("Service room for ticket " + ticketId + ".");
     roomAttributes.setDiscoverable(false);
     roomAttributes.setMembersCanInvite(true);
-
-    if (podName != null) {
-      roomAttributes.setName("[" + podName + "] [" + groupId + "] Ticket Room #" + ticketId);
-    } else {
-      roomAttributes.setName("[" + groupId + "] Ticket Room #" + ticketId);
-    }
-
+    roomAttributes.setName(buildRoomName(podName, groupId, ticketId));
     roomAttributes.setReadOnly(false);
     roomAttributes.setPublic(false);
     roomAttributes.setViewHistory(viewHistory);
@@ -56,6 +49,44 @@ public class RoomService {
     LOGGER.info("Created new room: " + roomAttributes.getName());
 
     return room;
+  }
+
+  /**
+   * Builds a valid room name within the maximum number of characters
+   * @param podName the Pod name to be displayed
+   * @param groupId the GroupId
+   * @param ticketId the TicketId
+   * @return the built Room Name
+   */
+  private String buildRoomName(String podName, String groupId, String ticketId) {
+    int availableChars = 50 - ("[] Ticket Room #" + ticketId).length();
+
+    if (podName != null) {
+      availableChars -= "[] ".length();
+
+      podName = truncate(podName, Math.max(availableChars / 2, availableChars - groupId.length()));
+      groupId = truncate(groupId, availableChars - podName.length());
+
+      return "[" + podName + "] [" + groupId + "] Ticket Room #" + ticketId;
+    } else {
+      groupId = truncate(groupId, availableChars);
+
+      return "[" + groupId + "] Ticket Room #" + ticketId;
+    }
+  }
+
+  /**
+   * Truncates a string with a given length
+   * @param string the string to be truncated
+   * @param length the maximum length
+   * @return the truncated string
+   */
+  private String truncate(String string, int length) {
+    if (string.length() > length) {
+      return string.substring(0, length);
+    } else {
+      return string;
+    }
   }
 
   /**

--- a/helpdesk-message-proxy-service/src/test/java/org/symphonyoss/symphony/bots/helpdesk/messageproxy/service/RoomServiceTest.java
+++ b/helpdesk-message-proxy-service/src/test/java/org/symphonyoss/symphony/bots/helpdesk/messageproxy/service/RoomServiceTest.java
@@ -3,11 +3,13 @@ package org.symphonyoss.symphony.bots.helpdesk.messageproxy.service;
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 import org.symphonyoss.client.SymphonyClient;
@@ -34,6 +36,12 @@ public class RoomServiceTest {
   private static final String ROOM_ID = "2541793";
 
   private static final String PODNAME = "PODNAME";
+
+  private static final String LONG_PODNAME = "EXCEEDINGLY LONG PODNAME";
+
+  private static final String LONG_GROUP_ID = "exceedinglyLongGroupId";
+
+  private static final String EXPECTED_LONG_NAME = "[EXCEEDINGLY] [exceedinglyL] Ticket Room #WBG23VD1";
 
   private RoomService service;
 
@@ -69,6 +77,18 @@ public class RoomServiceTest {
 
     assertEquals(ROOM_ID, room.getId());
     assertEquals(Boolean.FALSE, room.getRoomDetail().getRoomAttributes().getViewHistory());
+  }
+
+  @Test
+  public void createRoomWithLongTags() throws RoomException {
+    doReturn(mockRoom()).when(roomService).createRoom(any(SymRoomAttributes.class));
+
+    Room room = service.createServiceStream(TICKET_ID, LONG_GROUP_ID, LONG_PODNAME);
+
+    assertEquals(ROOM_ID, room.getId());
+    ArgumentCaptor<SymRoomAttributes> captor = ArgumentCaptor.forClass(SymRoomAttributes.class);
+    verify(roomService).createRoom(captor.capture());
+    assertEquals(EXPECTED_LONG_NAME, captor.getValue().getName());
   }
 
   private void mockGetLocalUser() {

--- a/helpdesk-message-proxy-service/src/test/java/org/symphonyoss/symphony/bots/helpdesk/messageproxy/service/RoomServiceTest.java
+++ b/helpdesk-message-proxy-service/src/test/java/org/symphonyoss/symphony/bots/helpdesk/messageproxy/service/RoomServiceTest.java
@@ -27,7 +27,7 @@ public class RoomServiceTest {
 
   private static final String GROUP_ID = "unitTest";
 
-  private static final String TICKET_ID = "WBG23VD1";
+  private static final String TICKET_ID = "WBG23VD1A6";
 
   private static final long USER_ID = 23011987l;
 
@@ -41,7 +41,7 @@ public class RoomServiceTest {
 
   private static final String LONG_GROUP_ID = "exceedinglyLongGroupId";
 
-  private static final String EXPECTED_LONG_NAME = "[EXCEEDINGLY] [exceedinglyL] Ticket Room #WBG23VD1";
+  private static final String EXPECTED_LONG_NAME = "[EXCEEDINGLY] [exceedingl] Ticket Room #WBG23VD1A6";
 
   private RoomService service;
 


### PR DESCRIPTION
This PR aims to fix cross-pod creation that was triggering:
{"code":400,"message":"Chosen name must be less than 50 characters"}

The chosen method involves truncating both the podName and groupId if necessary. It will calculate the available characters to be used in both those tags, resizing them smartly. If both tags are too long, half the available characters will be assigned to each.