### PR TITLE
APP-1713 Added ellipsis character at end of truncated string

### DIFF
--- a/helpdesk-message-proxy-service/src/main/java/org/symphonyoss/symphony/bots/helpdesk/messageproxy/service/RoomService.java
+++ b/helpdesk-message-proxy-service/src/main/java/org/symphonyoss/symphony/bots/helpdesk/messageproxy/service/RoomService.java
@@ -78,14 +78,14 @@ public class RoomService {
   }
 
   /**
-   * Truncates a string with a given length
+   * Truncates a string with a given length, placing an ellipsis character at the end of it
    * @param value the string to be truncated
    * @param length the maximum length
    * @return the truncated string
    */
   private String truncate(String value, int length) {
     if (value.length() > length) {
-      return value.substring(0, length).trim();
+      return value.substring(0, length - 1) + "…";
     } else {
       return value;
     }

--- a/helpdesk-message-proxy-service/src/test/java/org/symphonyoss/symphony/bots/helpdesk/messageproxy/service/RoomServiceTest.java
+++ b/helpdesk-message-proxy-service/src/test/java/org/symphonyoss/symphony/bots/helpdesk/messageproxy/service/RoomServiceTest.java
@@ -41,7 +41,7 @@ public class RoomServiceTest {
 
   private static final String LONG_GROUP_ID = "exceedinglyLongGroupId";
 
-  private static final String EXPECTED_LONG_NAME = "[EXCEEDINGLY] [exceedingl] Ticket Room #WBG23VD1A6";
+  private static final String EXPECTED_LONG_NAME = "[EXCEEDINGL…] [exceeding…] Ticket Room #WBG23VD1A6";
 
   private RoomService service;
 


### PR DESCRIPTION
This aims to make it more explicit to the agent in a service room that the original podName/companyName or GroupId has been truncated.