### PR TITLE
APP-1713 Added default value for company field in new ticket message

### DIFF
--- a/helpdesk-message-proxy-service/src/main/java/org/symphonyoss/symphony/bots/helpdesk/messageproxy/service/TicketService.java
+++ b/helpdesk-message-proxy-service/src/main/java/org/symphonyoss/symphony/bots/helpdesk/messageproxy/service/TicketService.java
@@ -139,7 +139,11 @@ public class TicketService {
       SymUser symUser = symphonyClient.getUsersClient().getUserFromId(message.getFromUserId());
       String username = symUser.getDisplayName();
       builder.username(username);
-      builder.company(symUser.getCompany());
+      if (symUser.getCompany() != null) {
+        builder.company(symUser.getCompany());
+      } else {
+        builder.company("N/A");
+      }
       builder.question(getQuestionFromMessage(message, username));
     } catch (UsersClientException e) {
       LOGGER.error("Could not get user info: ", e);

--- a/helpdesk-message-proxy-service/src/main/java/org/symphonyoss/symphony/bots/helpdesk/messageproxy/service/TicketService.java
+++ b/helpdesk-message-proxy-service/src/main/java/org/symphonyoss/symphony/bots/helpdesk/messageproxy/service/TicketService.java
@@ -34,7 +34,9 @@ public class TicketService {
   private static final String SERVICE_ROOM_WAS_NOT_CREATED =
       "There was a problem trying to create the service room. Please try again.";
 
-  private static final String DEFAULT_CLIENT_NAME = "Client";
+  private static final String DEFAULT_CLIENT_NAME = "N/A";
+
+  private static final String DEFAULT_COMPANY_NAME = "N/A";
 
   private static final String CHIME_MESSAGE = "%s sent a chime!";
 
@@ -139,10 +141,10 @@ public class TicketService {
       SymUser symUser = symphonyClient.getUsersClient().getUserFromId(message.getFromUserId());
       String username = symUser.getDisplayName();
       builder.username(username);
-      if (symUser.getCompany() != null) {
+      if (!StringUtils.isEmpty(symUser.getCompany())) {
         builder.company(symUser.getCompany());
       } else {
-        builder.company("N/A");
+        builder.company(DEFAULT_COMPANY_NAME);
       }
       builder.question(getQuestionFromMessage(message, username));
     } catch (UsersClientException e) {


### PR DESCRIPTION
This PR aims to fix an exception that was triggered when a client user tried to open a ticket, but that user had no value in field "company" (this is probably some bug with the user and should be verified in some other part of the Symphony project, but now at least we got that corner case covered by the bot).