### PR TITLE
PLAT-4966 Fixed agent messages not proxying after bot app restarts

### DIFF
--- a/helpdesk-ai/src/main/java/org/symphonyoss/symphony/bots/ai/impl/SymphonyAi.java
+++ b/helpdesk-ai/src/main/java/org/symphonyoss/symphony/bots/ai/impl/SymphonyAi.java
@@ -104,7 +104,11 @@ public class SymphonyAi implements Ai {
   @Override
   public AiConversation getConversation(SymphonyAiSessionKey aiSessionKey) {
     AiSessionContext aiSessionContext = aiSessionContextManager.getSessionContext(aiSessionKey);
-    return aiConversationManager.getConversation(aiSessionContext);
+    if (aiSessionContext != null) {
+      return aiConversationManager.getConversation(aiSessionContext);
+    } else {
+      return null;
+    }
   }
 
   /**


### PR DESCRIPTION
This aims to fix the NullPointerException that was triggering when aiSessionContext was null in this case, the calling class handles the null result correctly, so this should fix the bug in all tested cases.