### PR TITLE
PLAT-1560 Button Claim/Approve/Deny is duplicated after agent reinstalls HelpDesk app from Symphony Market

### DIFF
--- a/helpdesk-dynamic-rendering/package.json
+++ b/helpdesk-dynamic-rendering/package.json
@@ -75,8 +75,7 @@
     "babel-polyfill": "^6.23.0",
     "base64-url": "^2.2.0",
     "handlebars-loader": "^1.5.0",
-    "symphony-app-authentication-fe": "1.0.1",
-    "symphony-integration-commons": "0.1.30"
+    "symphony-app-authentication-fe": "1.0.1"
   },
   "repository": {
     "type": "git",

--- a/helpdesk-dynamic-rendering/src/main/webapp/enrichers/__tests__/actionAttachmentEnricherTest.js
+++ b/helpdesk-dynamic-rendering/src/main/webapp/enrichers/__tests__/actionAttachmentEnricherTest.js
@@ -1,10 +1,10 @@
-import { MessageEnricherBase } from 'symphony-integration-commons';
+import MessageEnricher from '../messageEnricher';
 import actionFactory from '../../utils/actionFactory';
 import attachmentActions from '../../templates/attachmentActions.hbs';
 
 import ActionAttachmentEnricher from '../actionAttachmentEnricher';
 
-jest.mock('symphony-integration-commons');
+jest.mock('../messageEnricher');
 jest.mock('../../utils/actionFactory');
 jest.mock('../../templates/attachmentActions.hbs');
 
@@ -90,7 +90,7 @@ describe('Action Attachment Enricher', () => {
     it('Should create a new action attachment enricher', () => {
         actionAttachmentEnricher = new ActionAttachmentEnricher();
 
-        expect(MessageEnricherBase.mock.calls.length).toBe(1);
+        expect(MessageEnricher.mock.calls.length).toBe(1);
         expect(typeof actionAttachmentEnricher.enrich === 'function').toBe(true);
         expect(typeof actionAttachmentEnricher.action === 'function').toBe(true);
     });

--- a/helpdesk-dynamic-rendering/src/main/webapp/enrichers/__tests__/actionClaimTicketEnricherTest.js
+++ b/helpdesk-dynamic-rendering/src/main/webapp/enrichers/__tests__/actionClaimTicketEnricherTest.js
@@ -1,4 +1,4 @@
-import { MessageEnricherBase } from 'symphony-integration-commons';
+import MessageEnricher from '../messageEnricher';
 import { getUserId, getRooms } from '../../utils/userUtils';
 import actionFactory from '../../utils/actionFactory';
 import { renderErrorMessage } from '../../utils/errorMessage';
@@ -7,7 +7,7 @@ const base64 = require('base64-url');
 
 import ActionClaimTicketEnricher from '../actionClaimTicketEnricher';
 
-jest.mock('symphony-integration-commons');
+jest.mock('../messageEnricher');
 jest.mock('../../utils/userUtils');
 jest.mock('../../utils/actionFactory');
 jest.mock('../../utils/errorMessage');
@@ -129,7 +129,7 @@ describe('Action Claim Ticket Enricher', () => {
         it('Should create a new action claim ticket enricher', () => {
             actionClaimTicketEnricher = new ActionClaimTicketEnricher();
 
-            expect(MessageEnricherBase.mock.calls.length).toBe(1);
+            expect(MessageEnricher.mock.calls.length).toBe(1);
             expect(typeof actionClaimTicketEnricher.enrich === 'function').toBe(true);
             expect(typeof actionClaimTicketEnricher.action === 'function').toBe(true);
         });

--- a/helpdesk-dynamic-rendering/src/main/webapp/enrichers/__tests__/attachmentEnricherTest.js
+++ b/helpdesk-dynamic-rendering/src/main/webapp/enrichers/__tests__/attachmentEnricherTest.js
@@ -1,4 +1,4 @@
-import { MessageEnricherBase } from 'symphony-integration-commons';
+import MessageEnricher from '../messageEnricher';
 import actionFactory from '../../utils/actionFactory';
 import AttachmentService from '../../services/attachmentService';
 import { getUserId } from '../../utils/userUtils';
@@ -8,7 +8,7 @@ import attachmentActions from '../../templates/attachmentActions.hbs';
 import AttachmentEnricher from '../attachmentEnricher';
 import {approveAttachment} from "../../api/apiCalls";
 
-jest.mock('symphony-integration-commons');
+jest.mock('../messageEnricher');
 jest.mock('../../utils/actionFactory');
 jest.mock('../../services/attachmentService');
 jest.mock('../../utils/userUtils');
@@ -163,7 +163,7 @@ describe('Attachment Enricher', () => {
 
         attachmentEnricher = new AttachmentEnricher();
 
-        expect(MessageEnricherBase.mock.calls.length).toBe(1);
+        expect(MessageEnricher.mock.calls.length).toBe(1);
         expect(AttachmentService.mock.calls.length).toBe(1);
         expect(attachmentEnricher.services.attachmentService).toEqual(mockAttachmentService);
 

--- a/helpdesk-dynamic-rendering/src/main/webapp/enrichers/__tests__/claimTicketEnricherTest.js
+++ b/helpdesk-dynamic-rendering/src/main/webapp/enrichers/__tests__/claimTicketEnricherTest.js
@@ -1,4 +1,4 @@
-import { MessageEnricherBase } from 'symphony-integration-commons';
+import MessageEnricher from '../messageEnricher';
 import actionFactory from '../../utils/actionFactory';
 import TicketService from '../../services/ticketService';
 import { getUserId, getRooms } from '../../utils/userUtils';
@@ -8,7 +8,7 @@ const base64 = require('base64-url');
 
 import ClaimTicketEnricher from '../claimTicketEnricher';
 
-jest.mock('symphony-integration-commons');
+jest.mock('../messageEnricher');
 jest.mock('../../utils/actionFactory');
 jest.mock('../../services/ticketService');
 jest.mock('../../utils/userUtils');
@@ -209,7 +209,7 @@ describe('Claim Ticket Enricher', () => {
         claimTicketActions.mockReturnValue(mockTemplate);
     });
     beforeEach(() => {
-        MessageEnricherBase.mockClear();
+        MessageEnricher.mockClear();
         getUserId.mockClear();
         getRooms.mockClear();
         base64.escape.mockClear();
@@ -226,7 +226,7 @@ describe('Claim Ticket Enricher', () => {
 
         claimTicketEnricher = new ClaimTicketEnricher();
 
-        expect(MessageEnricherBase.mock.calls.length).toBe(1);
+        expect(MessageEnricher.mock.calls.length).toBe(1);
         expect(TicketService.mock.calls.length).toBe(1);
         expect(claimTicketEnricher.services.ticketService).toEqual(mockTicketService);
 

--- a/helpdesk-dynamic-rendering/src/main/webapp/enrichers/actionAttachmentEnricher.js
+++ b/helpdesk-dynamic-rendering/src/main/webapp/enrichers/actionAttachmentEnricher.js
@@ -1,4 +1,4 @@
-import { MessageEnricherBase } from 'symphony-integration-commons';
+import MessageEnricher from './messageEnricher';
 import actionFactory from '../utils/actionFactory';
 
 const actions = require('../templates/attachmentActions.hbs');
@@ -8,9 +8,9 @@ const messageEvents = [
   'com.symphony.bots.helpdesk.event.makerchecker.action.performed',
 ];
 
-export default class ActionAttachmentEnricher extends MessageEnricherBase {
-  constructor() {
-    super(enricherServiceName, messageEvents);
+export default class ActionAttachmentEnricher extends MessageEnricher {
+  constructor(application) {
+    super(enricherServiceName, messageEvents, application);
   }
 
   enrich(type, entity) {

--- a/helpdesk-dynamic-rendering/src/main/webapp/enrichers/actionClaimTicketEnricher.js
+++ b/helpdesk-dynamic-rendering/src/main/webapp/enrichers/actionClaimTicketEnricher.js
@@ -1,4 +1,4 @@
-import { MessageEnricherBase } from 'symphony-integration-commons';
+import MessageEnricher from './messageEnricher';
 import { getUserId, getRooms } from '../utils/userUtils';
 import actionFactory from '../utils/actionFactory';
 import { renderErrorMessage } from '../utils/errorMessage';
@@ -12,9 +12,9 @@ const messageEvents = [
   'com.symphony.bots.helpdesk.event.ticket.accept',
 ];
 
-export default class ActionClaimTicketEnricher extends MessageEnricherBase {
-  constructor() {
-    super(enricherServiceName, messageEvents);
+export default class ActionClaimTicketEnricher extends MessageEnricher {
+  constructor(application) {
+    super(enricherServiceName, messageEvents, application);
   }
 
   enrich(type, entity) {

--- a/helpdesk-dynamic-rendering/src/main/webapp/enrichers/attachmentEnricher.js
+++ b/helpdesk-dynamic-rendering/src/main/webapp/enrichers/attachmentEnricher.js
@@ -1,4 +1,4 @@
-import { MessageEnricherBase } from 'symphony-integration-commons';
+import MessageEnricher from './messageEnricher';
 import actionFactory from '../utils/actionFactory';
 import AttachmentService from '../services/attachmentService';
 import { getUserId } from '../utils/userUtils';
@@ -16,9 +16,9 @@ function AttachmentException(messageException) {
   this.name = 'AttachmentException';
 }
 
-export default class AttachmentEnricher extends MessageEnricherBase {
-  constructor() {
-    super(enricherServiceName, messageEvents);
+export default class AttachmentEnricher extends MessageEnricher {
+  constructor(application) {
+    super(enricherServiceName, messageEvents, application);
 
     const attachmentService = new AttachmentService(enricherServiceName);
 

--- a/helpdesk-dynamic-rendering/src/main/webapp/enrichers/claimTicketEnricher.js
+++ b/helpdesk-dynamic-rendering/src/main/webapp/enrichers/claimTicketEnricher.js
@@ -1,4 +1,4 @@
-import { MessageEnricherBase } from 'symphony-integration-commons';
+import MessageEnricher from './messageEnricher';
 import actionFactory from '../utils/actionFactory';
 import TicketService from '../services/ticketService';
 import { getUserId, getRooms } from '../utils/userUtils';
@@ -17,9 +17,9 @@ function TicketException(messageException) {
   this.name = 'ticketException';
 }
 
-export default class ClaimTicketEnricher extends MessageEnricherBase {
-  constructor() {
-    super(enricherServiceName, messageEvents);
+export default class ClaimTicketEnricher extends MessageEnricher {
+  constructor(application) {
+    super(enricherServiceName, messageEvents, application);
 
     const ticketService = new TicketService(enricherServiceName);
 

--- a/helpdesk-dynamic-rendering/src/main/webapp/enrichers/messageEnricher.js
+++ b/helpdesk-dynamic-rendering/src/main/webapp/enrichers/messageEnricher.js
@@ -1,0 +1,24 @@
+export default class MessageEnricher {
+  constructor(name, messageEvents, application) {
+    this._name = name;
+    this.messageEvents = messageEvents;
+    this.application = application;
+    this.implements = ['enrich', 'action'];
+  }
+
+  get name() {
+    return this._name;
+  }
+
+  init() {
+    SYMPHONY.services.make(this._name, this, this.implements, true);
+  }
+
+  register() {
+    const entity = SYMPHONY.services.subscribe('entity');
+
+    this.messageEvents.forEach((messageEvent) => {
+      entity.registerRendererEnricher(messageEvent, {}, this._name, this.application);
+    });
+  }
+}

--- a/helpdesk-dynamic-rendering/src/main/webapp/js/controller.js
+++ b/helpdesk-dynamic-rendering/src/main/webapp/js/controller.js
@@ -6,15 +6,15 @@ import ActionClaimTicketEnricher from '../enrichers/actionClaimTicketEnricher';
 import AttachmentEnricher from '../enrichers/attachmentEnricher';
 import ActionAttachmentEnricher from '../enrichers/actionAttachmentEnricher';
 
-const claimTicketEnricher = new ClaimTicketEnricher();
-const attachmentEnricher = new AttachmentEnricher();
-const actionClaimTicketEnricher = new ActionClaimTicketEnricher();
-const actionAttachmentEnricher = new ActionAttachmentEnricher();
-
 const appName = getParameterByName('id');
 const authenticationURL = getParameterByName('baseAuthenticationURL');
 const appId = appName || 'helpdesk';
 const controllerName = `${appId}:controller`;
+
+const claimTicketEnricher = new ClaimTicketEnricher(appId);
+const attachmentEnricher = new AttachmentEnricher(appId);
+const actionClaimTicketEnricher = new ActionClaimTicketEnricher(appId);
+const actionAttachmentEnricher = new ActionAttachmentEnricher(appId);
 
 const initEnrichers = () => {
   claimTicketEnricher.init();


### PR DESCRIPTION
- Remove dependency from 'symphony-integration-commons'
- Include 'appId' as part of the enricher registration